### PR TITLE
chore(flake/nixpkgs): `f1c9c23a` -> `442db942`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -448,11 +448,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654126564,
-        "narHash": "sha256-sgDXDKGmUG4h7OPDOHyQggFQ08ZqVzUIPi8351yhugY=",
+        "lastModified": 1654245945,
+        "narHash": "sha256-PV6MZ+HuNnyLxQGa2rwt0BmCRkQS2xqhc+SeJLQM+WU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f1c9c23aad972787f00f175651e4cb0d7c7fd5ea",
+        "rev": "442db9429b9fbdb6352cfb937afc8ecccfe2633f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`442db942`](https://github.com/NixOS/nixpkgs/commit/442db9429b9fbdb6352cfb937afc8ecccfe2633f) | `coq: 8.15.1 → 8.15.2`                                                           |
| [`73812431`](https://github.com/NixOS/nixpkgs/commit/73812431fbcf1aa42a76543b14f939f0d5df543d) | `compcert: add support for Coq 8.15.2`                                           |
| [`595e59d4`](https://github.com/NixOS/nixpkgs/commit/595e59d4b020696e94b1314b222365127d31d351) | `coqPackages.VST: fix build with Coq 8.15.2`                                     |
| [`2841a287`](https://github.com/NixOS/nixpkgs/commit/2841a2876eb5eb47218a0770ff33c4abc936807d) | `_1password-gui-beta: 8.8.0-11.BETA -> 8.8.0-119.BETA`                           |
| [`c0ac5b76`](https://github.com/NixOS/nixpkgs/commit/c0ac5b76d3d7c5c1140cd4556dae052ed481b9a9) | `gpxsee: 10.5 → 11.0`                                                            |
| [`1dd3c254`](https://github.com/NixOS/nixpkgs/commit/1dd3c254ad5005b5d946e8e2154c1394e0ffd11f) | `python310Packages.mkdocs-material: update disable`                              |
| [`d77c6814`](https://github.com/NixOS/nixpkgs/commit/d77c6814b3ead77e5c56a20a47573b433750b67a) | `home-assistant: 2022.6.0 -> 2022.6.1`                                           |
| [`91e442ae`](https://github.com/NixOS/nixpkgs/commit/91e442aec1d5c5201b0b2049570784185edb19b6) | `python3Packages.yolink-api: 0.0.5 -> 0.0.6`                                     |
| [`3e13b6f6`](https://github.com/NixOS/nixpkgs/commit/3e13b6f634a404146906e2bb14b546dc46930809) | `python3Packages.pyhiveapi: 0.5.4 -> 0.5.5`                                      |
| [`f2b9dde8`](https://github.com/NixOS/nixpkgs/commit/f2b9dde8606af198ffe71becf537b8aac6fb8f8b) | `python310Packages.mkdocs-material: 8.2.16 -> 8.3.0`                             |
| [`236cc297`](https://github.com/NixOS/nixpkgs/commit/236cc2971ac72acd90f0ae3a797f9f83098b17ec) | `vector: 0.21.2 -> 0.22.0`                                                       |
| [`ff6d7982`](https://github.com/NixOS/nixpkgs/commit/ff6d79820dfb057867b639dc81259c7f946d5bef) | `cloud-hypervisor: 23.1 -> 24.0`                                                 |
| [`0a91385f`](https://github.com/NixOS/nixpkgs/commit/0a91385fcf982c2087f4b3e8daf612edf365a2b8) | `bacon: 2.1.0 -> 2.2.0`                                                          |
| [`2701e6f3`](https://github.com/NixOS/nixpkgs/commit/2701e6f31210c967a9b429259ba9ddebd394d913) | `afterburn: 5.2.0 -> 5.3.0`                                                      |
| [`6dfc8be3`](https://github.com/NixOS/nixpkgs/commit/6dfc8be36ad8b39b0c3311ed99dea579348714d1) | `cargo-llvm-lines: 0.4.14 -> 0.4.15`                                             |
| [`b9a4e728`](https://github.com/NixOS/nixpkgs/commit/b9a4e72883d3c8cdb674ee1e80d7aa7da25fd96d) | `terraform-providers.http: 2.1.0 -> 2.2.0`                                       |
| [`e8d83130`](https://github.com/NixOS/nixpkgs/commit/e8d83130fbbf0fd3ad465ab27310df6bcddcbe45) | `python3Packages.coloredlogs: update hash`                                       |
| [`f27e343a`](https://github.com/NixOS/nixpkgs/commit/f27e343a42eae19b47db55231bd617d4de8abd53) | `python310Packages.neo4j-driver: 4.4.3 -> 4.4.4`                                 |
| [`db1bad62`](https://github.com/NixOS/nixpkgs/commit/db1bad625cb0949d29a9ee891992c6612d707fc4) | `python310Packages.setupmeta: 3.3.1 -> 3.3.2`                                    |
| [`37a2a629`](https://github.com/NixOS/nixpkgs/commit/37a2a6297ca745bcef8dac5b76179b04c7b0f91b) | `python310Packages.faraday-plugins: 1.6.6 -> 1.6.7`                              |
| [`5c631577`](https://github.com/NixOS/nixpkgs/commit/5c63157740a3f22f85462593e600a8c6760e0d52) | `python310Packages.adafruit-platformdetect: 3.24.0 -> 3.24.1`                    |
| [`a1a9aa11`](https://github.com/NixOS/nixpkgs/commit/a1a9aa11f6062c8d3a0e47f69e67ad11f9bb3d5b) | `python310Packages.ua-parser: run tests`                                         |
| [`4b190c08`](https://github.com/NixOS/nixpkgs/commit/4b190c0888a4171e93e07eabbc88e45885dc9130) | `famistudio: init at 3.3.0`                                                      |
| [`1bab0eb3`](https://github.com/NixOS/nixpkgs/commit/1bab0eb399a7dc2e28060346758e31668ff7b14c) | `fmtoy: init at unstable-2021-12-24`                                             |
| [`1cda678e`](https://github.com/NixOS/nixpkgs/commit/1cda678ea067236ffd98476bf1084c2d45ada81c) | `vgmtools: init at unstable-2022-05-23`                                          |
| [`65db7577`](https://github.com/NixOS/nixpkgs/commit/65db75774bcbbd64afe58147e70191003bd3d504) | `mmlgui: init at unstable-2022-05-24`                                            |
| [`bcef993b`](https://github.com/NixOS/nixpkgs/commit/bcef993bd2854b61b94cab833fabc3c6dc324ff5) | `vgmplay-libvgm: init at unstable-2022-03-17`                                    |
| [`0454ad0d`](https://github.com/NixOS/nixpkgs/commit/0454ad0dcf454ce4b67b45993790005584bda6d6) | `libvgm: init at unstable-2022-05-27`                                            |
| [`98e0b747`](https://github.com/NixOS/nixpkgs/commit/98e0b747df49e3edd1aa2c4e7fcc98361a17b09f) | `organicmaps: 2022.04.27-2 -> 2022.05.31-10`                                     |
| [`c0e56baa`](https://github.com/NixOS/nixpkgs/commit/c0e56baaba89d9a62b51274432b16d37a178cd2a) | `gnomeExtensions.freon: fix patch for v48, simplify`                             |
| [`4bc488dd`](https://github.com/NixOS/nixpkgs/commit/4bc488ddfea589673459d980d05349281c738b89) | `wiimms-iso-tools: add -fcommon workaround`                                      |
| [`ff3f2a40`](https://github.com/NixOS/nixpkgs/commit/ff3f2a403701d9b5b8915d98d902a257d9c7c0cb) | `python310Packages.flask-jwt-extended: 4.4.0 -> 4.4.1`                           |
| [`e4dbad58`](https://github.com/NixOS/nixpkgs/commit/e4dbad58d2b43a9c40808a117c976f787f0a06f7) | `libdigidocpp: Fix PKCS11 module library path`                                   |
| [`1d46988e`](https://github.com/NixOS/nixpkgs/commit/1d46988e136fec6d885877b74dba7f70ee9c70df) | `qdigidoc: Wrap just once`                                                       |
| [`352dd817`](https://github.com/NixOS/nixpkgs/commit/352dd81758b44e670e0cb7193e44a591d8d24152) | `notmuch: Cleanup unnecessary workaround`                                        |
| [`33e7b2cd`](https://github.com/NixOS/nixpkgs/commit/33e7b2cdcbeaa7883a9e34482ac161f721f4f5b2) | `notmuch: 0.35 -> 0.36`                                                          |
| [`0d317531`](https://github.com/NixOS/nixpkgs/commit/0d317531670bec6def20bc4dddfcaf0e705f6b2b) | `ooniprobe-cli: 3.14.2 -> 3.15.0`                                                |
| [`6d4dfe79`](https://github.com/NixOS/nixpkgs/commit/6d4dfe7906d77f699d1887671ba96792903d5bd4) | `dolphin-emu-{beta,primehack}: adjust platforms`                                 |
| [`c3cb6d53`](https://github.com/NixOS/nixpkgs/commit/c3cb6d53ed8b6109e37b3f547a85da054870f60a) | `dolphin-emu-primehack: 1.0.5 -> 1.0.6`                                          |
| [`ef126af5`](https://github.com/NixOS/nixpkgs/commit/ef126af56ee559a031ec88b0519f272211ed6129) | `python310Packages.google-cloud-secret-manager: 2.10.0 -> 2.11.0`                |
| [`24d3a141`](https://github.com/NixOS/nixpkgs/commit/24d3a1410e4d6a9001328c6b589161bda619e9ca) | `python310Packages.zigpy: 0.45.1 -> 0.46.0`                                      |
| [`02e71fed`](https://github.com/NixOS/nixpkgs/commit/02e71fedd639ccfae67262b61c5065a8b31db91f) | `python310Packages.hijri-converter: 2.2.3 -> 2.2.4`                              |
| [`57b107c7`](https://github.com/NixOS/nixpkgs/commit/57b107c726ca4d0da44b703f0cb3be14149020f6) | `gnome.geary: fix build with vala 0.56`                                          |
| [`ca19b56a`](https://github.com/NixOS/nixpkgs/commit/ca19b56a93c3ce4465b9e9386625562f874bb75d) | `mercurial: add techknowlogick as maintainer`                                    |
| [`98bc447a`](https://github.com/NixOS/nixpkgs/commit/98bc447a8a41fb3e75a84b77c4671097f3da9f91) | `mercurial: 6.1.2 -> 6.1.3`                                                      |
| [`fe1c890c`](https://github.com/NixOS/nixpkgs/commit/fe1c890c2dd217fb079e86a9517ec852d2381d65) | `go-mk: remove`                                                                  |
| [`94cc2f9c`](https://github.com/NixOS/nixpkgs/commit/94cc2f9c9f0accc56c8fad8a9c9106d8fef5ac46) | `exa: fix build with rustc 1.61`                                                 |
| [`a7b9951b`](https://github.com/NixOS/nixpkgs/commit/a7b9951bf086d697c9baa6af0b590f3ccac700ad) | `go-repo-root: remove`                                                           |
| [`055f2cb1`](https://github.com/NixOS/nixpkgs/commit/055f2cb18ecc702d1639a735c3ca953466e8f47e) | `corgi: remove`                                                                  |
| [`8bfbb8c6`](https://github.com/NixOS/nixpkgs/commit/8bfbb8c6c38cd2d4f864e2319eb5505cd946c730) | `etcd_3_5: 3.5.1 -> 3.5.4`                                                       |
| [`2c8ed7e0`](https://github.com/NixOS/nixpkgs/commit/2c8ed7e04b50f95800099743ae97bbd61c63c0cf) | `python310Packages.azure-mgmt-applicationinsights: 3.0.0 -> 3.1.0`               |
| [`887c7e4e`](https://github.com/NixOS/nixpkgs/commit/887c7e4eb761ba84f6bc7140d0d4f327673c5c4b) | `python310Packages.marshmallow: 3.15.0 -> 3.16.0`                                |
| [`a7de9e82`](https://github.com/NixOS/nixpkgs/commit/a7de9e82d297e0f61cedd160e14bbc4d2b2f475f) | `git-annex-remote-b2: remove`                                                    |
| [`4e442979`](https://github.com/NixOS/nixpkgs/commit/4e4429797467dfd74d137c5f4934fc22313d0b31) | `xmpp-client: remove`                                                            |
| [`237366d8`](https://github.com/NixOS/nixpkgs/commit/237366d847485423c592e2c9a22def4e373e8d64) | `pond: remove`                                                                   |
| [`5d06b5b8`](https://github.com/NixOS/nixpkgs/commit/5d06b5b8d4f02c33951580bbb5f6fb112151fbf4) | `ventoy-bin: 1.0.74 -> 1.0.75`                                                   |
| [`fbb3af63`](https://github.com/NixOS/nixpkgs/commit/fbb3af63675ddc4a6481e9f489ba9d451fbf9a7a) | `python310Packages.hahomematic: 1.7.3 -> 1.8.0`                                  |
| [`74414ea7`](https://github.com/NixOS/nixpkgs/commit/74414ea759523ec85d18725fcd53ef82a845e338) | `gawp: remove`                                                                   |
| [`9488ef95`](https://github.com/NixOS/nixpkgs/commit/9488ef9504802bb417d40e2935069b9e4c4ed0bb) | `i3cat: remove`                                                                  |
| [`44891c51`](https://github.com/NixOS/nixpkgs/commit/44891c51c621baa2ae255cf436bb61b660416485) | `ical2org: remove`                                                               |
| [`01db68fc`](https://github.com/NixOS/nixpkgs/commit/01db68fcf18507eed614a0ac9373bc91a44875d9) | `curl_unix_socket: remove`                                                       |
| [`d955d888`](https://github.com/NixOS/nixpkgs/commit/d955d8882939c37e6484512f58120a382d5e34f1) | `goklp: remove`                                                                  |
| [`e50e5c05`](https://github.com/NixOS/nixpkgs/commit/e50e5c05c3cca92180f7e4bbded23a0c6ac232cc) | `python310Packages.datadiff: 1.1.6 -> 2.0.0`                                     |
| [`1be67172`](https://github.com/NixOS/nixpkgs/commit/1be67172269238fd5d3491d2ac6c29d3a22ab66a) | `python310Packages.asyncstdlib: 3.10.4 -> 3.10.5`                                |
| [`db228fed`](https://github.com/NixOS/nixpkgs/commit/db228fed78133ae3c7078772b43267c803702d5e) | `gimp: add pygtk dev output to build inputs`                                     |
| [`e00c7192`](https://github.com/NixOS/nixpkgs/commit/e00c71926f797ce9139276942c819370a2bcdd45) | `_1password-gui: 8.7.0 -> 8.7.1`                                                 |
| [`bb70f258`](https://github.com/NixOS/nixpkgs/commit/bb70f2587ba4ea1d239aa1b22e12435037bcd6d0) | `python310Packages.selenium: cleanup`                                            |
| [`6b825503`](https://github.com/NixOS/nixpkgs/commit/6b825503333268f04a57e7e8ba79cddb501bfdac) | `pgadmin: unpin eventlet dependency, cleanup`                                    |
| [`1a729fc8`](https://github.com/NixOS/nixpkgs/commit/1a729fc8308455609c8c79543b7b8736430a621b) | `citrix_workspace: drop support for 20.X`                                        |
| [`a833aefc`](https://github.com/NixOS/nixpkgs/commit/a833aefc2a94b2550e076ced9132b9b7b17df0e8) | `buf: 1.4.0 -> 1.5.0`                                                            |
| [`29696267`](https://github.com/NixOS/nixpkgs/commit/29696267a9ccd856cb8d9828f0737adeda2869ea) | ``swaynag-battery: init at version `0.2.0```                                     |
| [`b6307446`](https://github.com/NixOS/nixpkgs/commit/b6307446af0cce4e8a23669959b0b8820b21ae7b) | `python310Packages.types-requests: 2.27.29 -> 2.27.30`                           |
| [`75a6c931`](https://github.com/NixOS/nixpkgs/commit/75a6c931cbc063922c8f295438ef401902cd9e9b) | `checkov: 2.0.1175 -> 2.0.1186`                                                  |
| [`8235de6d`](https://github.com/NixOS/nixpkgs/commit/8235de6d5c9ef0d904a9fc8c20e017fd7db7092b) | `citrix_workspace: added myself as maintainer`                                   |
| [`fcea4008`](https://github.com/NixOS/nixpkgs/commit/fcea400842318d833e39e3be2e45d0a7447681a8) | `citrix_workspace: 21.12.0 -> 22.05.0`                                           |
| [`a142ecae`](https://github.com/NixOS/nixpkgs/commit/a142ecae78e994db1aac9573b165198deb7c9a7a) | `python310Packages.scmrepo: 0.0.23 -> 0.0.24`                                    |
| [`31194524`](https://github.com/NixOS/nixpkgs/commit/31194524277dbba788123cf926348c2a85385178) | `ocamlformat: remove unnecessary version check`                                  |
| [`1d0649f9`](https://github.com/NixOS/nixpkgs/commit/1d0649f9296d909b7bcc83a3b36558a18177e5e3) | ``phosh: restrict the `scale` config value to strictly positive values or null`` |
| [`58aef427`](https://github.com/NixOS/nixpkgs/commit/58aef42768cb7c72b1da9f6ef1367fbcca52d88f) | `fclones: 0.24.0 -> 0.25.0`                                                      |
| [`45e44285`](https://github.com/NixOS/nixpkgs/commit/45e44285c366a2e691a3e04ab66bc5415409acbf) | `python310Packages.twilio: 7.9.1 -> 7.9.2`                                       |
| [`7df93e3e`](https://github.com/NixOS/nixpkgs/commit/7df93e3e1cb7c774d9ba97d92730c70d0e6135eb) | `python310Packages.pytest-testmon: 1.3.1 -> 1.3.3`                               |
| [`e5b836ac`](https://github.com/NixOS/nixpkgs/commit/e5b836ac81450a7653a5e9f30093a853c686d755) | `python310Packages.aiopyarr: 22.2.2 -> 22.6.0`                                   |
| [`95fc12d1`](https://github.com/NixOS/nixpkgs/commit/95fc12d1b1ad564969a2624bce2d1a60dbbae900) | `python310Packages.adafruit-platformdetect: 3.23.0 -> 3.24.0`                    |
| [`dbb9d9ab`](https://github.com/NixOS/nixpkgs/commit/dbb9d9ab296d66200654634fa301f2332a522e80) | `python310Packages.statmake: relax cattrs constaint`                             |
| [`d4ee686f`](https://github.com/NixOS/nixpkgs/commit/d4ee686fbf058ef9debe374e56e40e2c62ae3d83) | `python310Packages.google-cloud-bigtable: 2.8.1 -> 2.10.0`                       |
| [`422838f2`](https://github.com/NixOS/nixpkgs/commit/422838f261171c1682120aa654e088564a09c500) | `python310Packages.hahomematic: 1.7.2 -> 1.7.3`                                  |
| [`9ea5e3d0`](https://github.com/NixOS/nixpkgs/commit/9ea5e3d040cb693f11d7423fdeb2701ad6c8c0af) | `podman-tui: 0.3.1 -> 0.4.0`                                                     |
| [`9a5c77c5`](https://github.com/NixOS/nixpkgs/commit/9a5c77c581c5f680852e40501ae4685eea0b26e8) | `nixos/new-lg4ff: fix kernel selection`                                          |
| [`81a5e28e`](https://github.com/NixOS/nixpkgs/commit/81a5e28eadf548c48bc63411df1175467c87e4c2) | `python310Packages.pyfaidx: 0.6.4 -> 0.7.0`                                      |
| [`0801cc0b`](https://github.com/NixOS/nixpkgs/commit/0801cc0bfb0368892b19cf89e3454666cdafaf7a) | `python310Packages.wcmatch: 8.3 -> 8.4`                                          |
| [`0ed7c187`](https://github.com/NixOS/nixpkgs/commit/0ed7c18701d553b1598765bd66fef0f95cf13d92) | `cfripper: 1.11.0 -> 1.12.0`                                                     |
| [`e9fb739e`](https://github.com/NixOS/nixpkgs/commit/e9fb739e597f60383d27e290e2932696cdada971) | `snakemake: 7.8.0 -> 7.8.1`                                                      |
| [`e6123938`](https://github.com/NixOS/nixpkgs/commit/e6123938cafa5f5a368090c68d9012adb980da5f) | `python310Packages.pydrive: drop (#175755)`                                      |
| [`4c3e9f09`](https://github.com/NixOS/nixpkgs/commit/4c3e9f091a3ca5d8e9df008488c6d6ccb6955181) | `check-meta: fix comment (#175517)`                                              |
| [`eae11bae`](https://github.com/NixOS/nixpkgs/commit/eae11baeafa591f344eeef3c0db9d7afe0c78e8b) | `python310Packages.tempest: 29.2.0 -> 30.1.0`                                    |
| [`cabf369f`](https://github.com/NixOS/nixpkgs/commit/cabf369f833af817f19b8ae11f15b91aed2121f3) | `phosh: allow fractional scaling`                                                |
| [`9ce157af`](https://github.com/NixOS/nixpkgs/commit/9ce157afc89e8a146d1cb5581db5a6c2bd1a51cf) | `mono: fix broken mono4 build on Darwin`                                         |
| [`1622a6cd`](https://github.com/NixOS/nixpkgs/commit/1622a6cdeb22f92b6875ee00c1ef03e6a5486335) | `mono: be more precise in flagging broken builds`                                |
| [`faa70514`](https://github.com/NixOS/nixpkgs/commit/faa705148c6b9b1f2f5d3863696fc56a684b9a03) | `wget2: 2.0.0 -> 2.0.1`                                                          |
| [`65144eb5`](https://github.com/NixOS/nixpkgs/commit/65144eb51455ff7f2ca639450129dc82af274ede) | `xh: 0.15.0 -> 0.16.1`                                                           |
| [`964e96b4`](https://github.com/NixOS/nixpkgs/commit/964e96b4cb5f68f74d341faa51d2a8131492cbf9) | `yle-dl: remove myself from maintainers`                                         |
| [`dbf0bb74`](https://github.com/NixOS/nixpkgs/commit/dbf0bb74420cbdccd13db89f51b7392bd56dda78) | `python310Packages.wsgi-intercept: 1.9.3 -> 1.10.0`                              |
| [`fbaef9d8`](https://github.com/NixOS/nixpkgs/commit/fbaef9d855e98cfbb5829f2f36aa7f0ca2d3eb8b) | `python310Packages.python-magic: 0.4.25 -> 0.4.26`                               |
| [`7782af87`](https://github.com/NixOS/nixpkgs/commit/7782af8721c2141f81ab5158180760bf8240f8fd) | `python310Packages.pytest-httpx: remove myself from maintainers`                 |
| [`f88db0ef`](https://github.com/NixOS/nixpkgs/commit/f88db0ef449440151c9698dbbde2c36e1e930d40) | `python310Packages.pyaxmlparser: 0.3.26 -> 0.3.27`                               |
| [`a25bebdf`](https://github.com/NixOS/nixpkgs/commit/a25bebdfd4544522f346b53668f3ee62d4fd65aa) | `python310Packages.msal: 1.17.0 -> 1.18.0`                                       |
| [`d60e225f`](https://github.com/NixOS/nixpkgs/commit/d60e225ffaaaffe99472c54214ddcc7990db1a36) | `ArchiSteamFarm.ui: update`                                                      |
| [`07747e38`](https://github.com/NixOS/nixpkgs/commit/07747e3884362ee5d57dd59858301bdd3d293f95) | `ArchiSteamFarm: 5.2.5.7 -> 5.2.6.3`                                             |
| [`ad34ff74`](https://github.com/NixOS/nixpkgs/commit/ad34ff74347e5a541c4049f2bd1575b738d2e831) | `python310Packages.oslo-utils: 4.12.2 -> 4.13.0`                                 |