### PR TITLE
chore(flake/nvim-lspconfig-src): `c5dae15c` -> `2a455c14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -644,11 +644,11 @@
     "nvim-lspconfig-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654094581,
-        "narHash": "sha256-TRIQdys/afLog+Rhjp7hsxSbhEi4gnTj9dHkWnxZPyg=",
+        "lastModified": 1654272327,
+        "narHash": "sha256-CcsXXrjfcdcfhGrmcZKrgm95fhojt35IgLuTt3OUkN4=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "c5dae15c0c94703a0565e8ba35a9f5cb96ca7b8a",
+        "rev": "2a455c148341c4faf2dd60401397fed35d084c59",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                 | Commit Message                                                    |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`2a455c14`](https://github.com/neovim/nvim-lspconfig/commit/2a455c148341c4faf2dd60401397fed35d084c59) | `docs: update server_configurations.md`                           |
| [`2c210dd7`](https://github.com/neovim/nvim-lspconfig/commit/2c210dd7ec5b2c53fa24bbb8005d6e6d08cec0b2) | `feat: add svlangserver support (#1916)`                          |
| [`cf65acc3`](https://github.com/neovim/nvim-lspconfig/commit/cf65acc323c3d4b43014c7aaa86e0515a6498234) | `docs: update server_configurations.md`                           |
| [`d99c4713`](https://github.com/neovim/nvim-lspconfig/commit/d99c4713dd87c78ac40b2a1447f34578af7ef7e7) | `feat: add apex_ls #1940`                                         |
| [`134a291f`](https://github.com/neovim/nvim-lspconfig/commit/134a291fecc5c1fa5d01e398d2d6ef03b3dc5149) | `fix(docs): vim.lsp.buf.format -> vim.lsp.buf.formatting (#1936)` |
| [`0b0afea6`](https://github.com/neovim/nvim-lspconfig/commit/0b0afea62c4d1fe11619cbd06832336b21febc40) | `docs: update server_configurations.md`                           |
| [`ed878490`](https://github.com/neovim/nvim-lspconfig/commit/ed8784904bfc3740a02db56b3410ba3b426f4c26) | `fix(dartls): explicitly pass the protocol to dartls (#1943)`     |
| [`6f265f07`](https://github.com/neovim/nvim-lspconfig/commit/6f265f07b2ea05e2f0e68c86fa1c2dee0739203a) | `style: fix bad formatting (#1944)`                               |