### PR TITLE
chore(flake/nvim-treesitter-src): `b922b2c3` -> `e4df4228`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
     "nvim-treesitter-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654167417,
-        "narHash": "sha256-3b5OAU4OdJeC8ki13K3aS4oI2MKTMDLrHHuUtYKP4c8=",
+        "lastModified": 1654358039,
+        "narHash": "sha256-rlIQBWzkGstO6yRkCCjdL1MVjAKXT8Hsi++/1FF49sw=",
         "owner": "nvim-treesitter",
         "repo": "nvim-treesitter",
-        "rev": "b922b2c3db1295d487ae0631a775608952489de6",
+        "rev": "e4df4228b7c07f98e55345b40ac0093d27d0d18c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                           | Commit Message                                |
| ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`e4df4228`](https://github.com/nvim-treesitter/nvim-treesitter/commit/e4df4228b7c07f98e55345b40ac0093d27d0d18c) | `highlights(php): highlight readonly keyword` |
| [`d7ec2e6a`](https://github.com/nvim-treesitter/nvim-treesitter/commit/d7ec2e6ab938b60baa5a9f4cd46d1d88d6da22ac) | `Update lockfile.json`                        |
| [`a94078a0`](https://github.com/nvim-treesitter/nvim-treesitter/commit/a94078a09874c4e95170e86cb325eeaef3504de0) | `Update lockfile.json`                        |