### PR TITLE
chore(flake/nixpkgs-master): `8420ca28` -> `66172026`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1654399896,
-        "narHash": "sha256-NTlMfaOtu2s7KHRrhuC4lBO8dUrUWAA3u53I9KwFXZY=",
+        "lastModified": 1654487477,
+        "narHash": "sha256-xUmOrDNzQFpPMnEdHO5EOuj4PWz5JKCon9wBXO265og=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8420ca28deba06a3c073c52cd3420cfa25902f42",
+        "rev": "66172026e025bfdf08d5be4f9b8d5be9b70f912f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                    |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`8dbfd523`](https://github.com/NixOS/nixpkgs/commit/8dbfd523ec9c0dd3c80093875855911666644767) | `python310Packages.nextcord: 2.0.0a10 -> 2.0.0b2`                                 |
| [`d33e96ee`](https://github.com/NixOS/nixpkgs/commit/d33e96ee4a28fda92f9fa159e110a1a825aa85fb) | `metadata-cleaner: 2.2.2 -> 2.2.3`                                                |
| [`d2a9a19e`](https://github.com/NixOS/nixpkgs/commit/d2a9a19e8aee6fad776bf0f43d9d5dda80444ff7) | `borgbackup: set meta.mainProgram`                                                |
| [`36aa013f`](https://github.com/NixOS/nixpkgs/commit/36aa013ff4a84f9316ddc7b9817592cb3e80d12b) | `borgbackup: 1.2.0 -> 1.2.1`                                                      |
| [`e4cb4bdb`](https://github.com/NixOS/nixpkgs/commit/e4cb4bdb05605d691ca31b54703f2866197944ef) | `gnaural: add -fcommon workaround`                                                |
| [`950a8601`](https://github.com/NixOS/nixpkgs/commit/950a860155b8daf4e65bfe530811b9a5941ec6de) | `iosevka: 14.0.1 → 15.5.0`                                                        |
| [`1935db39`](https://github.com/NixOS/nixpkgs/commit/1935db3988e3e3ed3cd268468092de0a9e1ac93e) | `iosevka: set home directory in build phase`                                      |
| [`87de4db5`](https://github.com/NixOS/nixpkgs/commit/87de4db5e66c7b3b0ef34707fdde7af3ffb580c4) | `pkgs/config.nix: Fix missing attribute when no config keys are undeclared`       |
| [`d36bc45d`](https://github.com/NixOS/nixpkgs/commit/d36bc45d47fddfa6e387c4efbb0f076a089a04d9) | `goa: 1.4.1 -> 3.7.6`                                                             |
| [`e0f8de61`](https://github.com/NixOS/nixpkgs/commit/e0f8de611640ad5ae015abd69a5e657f3ce1c4be) | `easyjson: use buildGoModule`                                                     |
| [`83a02852`](https://github.com/NixOS/nixpkgs/commit/83a028528ce30b3ddbfcbfb6a0d7e3b1e510e73d) | `chromiumDev: 104.0.5083.0 -> 104.0.5098.0`                                       |
| [`813520e6`](https://github.com/NixOS/nixpkgs/commit/813520e62490be7e0657f70982274b4895837300) | `uae: add -fcommon workaround`                                                    |
| [`417ae79c`](https://github.com/NixOS/nixpkgs/commit/417ae79c26cdaa4978077797d63b69f1c4ced245) | `trinity: pull upstream fix for -fno-common toolchains`                           |
| [`7320966b`](https://github.com/NixOS/nixpkgs/commit/7320966be6c4f5b4262a4b511d0af54d7a3e30bb) | `speech-tools: add -fcommon workaround`                                           |
| [`0758a0fa`](https://github.com/NixOS/nixpkgs/commit/0758a0fa275f0d12f3b8ff5daa6e96a2d519ad9f) | `roccat-tools: add -fcommon workaround`                                           |
| [`d306eea8`](https://github.com/NixOS/nixpkgs/commit/d306eea857c00d0e67f36ad17a0b281d3d46674d) | `oroborus: add -fcommon workaround`                                               |
| [`a38af493`](https://github.com/NixOS/nixpkgs/commit/a38af4931825722f973ad89e99d8c7e43fe6865a) | `lilo: add -fcommon workaround`                                                   |
| [`2d012163`](https://github.com/NixOS/nixpkgs/commit/2d012163f23495d81116960fae15288db5285ec7) | `nixos/uhub: fix plugins, set CAP_NET_BIND_SERVICE`                               |
| [`cc2548ae`](https://github.com/NixOS/nixpkgs/commit/cc2548ae81ab44d5f15d78a7d414ae90ccee170c) | `ircdog: use buildGoModule`                                                       |
| [`60ff8d23`](https://github.com/NixOS/nixpkgs/commit/60ff8d2306663d08621247b9416351a36183492e) | `ocamlPackages.magic: init at 0.7.3`                                              |
| [`11208c64`](https://github.com/NixOS/nixpkgs/commit/11208c64001f7c0c0073b6fd47c21bd9b1aff8aa) | `ocamlPackages.lo: init at 0.2.0`                                                 |
| [`85665ca9`](https://github.com/NixOS/nixpkgs/commit/85665ca9d489a6cc1352f9c16abe3106ea2f0d2d) | `ocamlPackages.duppy: init at 0.9.2`                                              |
| [`f3c53f43`](https://github.com/NixOS/nixpkgs/commit/f3c53f430f18e5c0a3c5d38669db5b817aabf2a2) | `ocamlPackages.dtools: init at 0.4.4`                                             |
| [`5ddc759a`](https://github.com/NixOS/nixpkgs/commit/5ddc759a4879cec6c87e853eec339dcf5546f6d5) | `dillo: add -fcommon workaround`                                                  |
| [`3fcf9f18`](https://github.com/NixOS/nixpkgs/commit/3fcf9f18ddfdbf108b371637410821b6f388ef67) | `python3Packages.black: disable test on aarch64-linux`                            |
| [`74fbade6`](https://github.com/NixOS/nixpkgs/commit/74fbade62f6c9cf492c478a840e2746a5f9b9005) | `qmk: 1.0.0 -> 1.1.0`                                                             |
| [`09e3c120`](https://github.com/NixOS/nixpkgs/commit/09e3c1209172a224d3ca6be2de4466f2612f4a4c) | `mcomix3: remove and alias it to mcomix`                                          |
| [`5a8e7406`](https://github.com/NixOS/nixpkgs/commit/5a8e7406ca7d56b1b1d8590d44ca1966887eb9ed) | `mcomix: init at 2.0.2`                                                           |
| [`7ed01662`](https://github.com/NixOS/nixpkgs/commit/7ed016627f9b7c3a0ab068cb526ad37ec2f8bcc7) | `ocamlPackages.pulseaudio: init at 0.1.5`                                         |
| [`754433d8`](https://github.com/NixOS/nixpkgs/commit/754433d82a58d18a3c492cc84b4eae794766d648) | `ocamlPackages.portaudio: init at 0.2.3`                                          |
| [`e5031b83`](https://github.com/NixOS/nixpkgs/commit/e5031b839b07a5432f12fd2505339c7cbdaabfd4) | `ocamlPackages.gstreamer: init at 0.3.1`                                          |
| [`e5b2c5f4`](https://github.com/NixOS/nixpkgs/commit/e5b2c5f447ff3cadbbaff89ef2d547eee07c250d) | `ocamlPackages.alsa: init at 3.0.0`                                               |
| [`58b3f669`](https://github.com/NixOS/nixpkgs/commit/58b3f6693151d6c3d4a3f542be4f7dfa429519e4) | ``linuxKernels.kernels.linux_xanmod: don't set `-Werror` by default``             |
| [`83171a1d`](https://github.com/NixOS/nixpkgs/commit/83171a1dba143d34c6611d62d30cda2b983cec79) | `linuxKernels.kernels.linux_xanmod: apply patch from review`                      |
| [`2badffbd`](https://github.com/NixOS/nixpkgs/commit/2badffbd9983350effe3a5fae7e46f2644e26d3d) | `imagemagick: 7.1.0-36 -> 7.1.0-37`                                               |
| [`d688ec7d`](https://github.com/NixOS/nixpkgs/commit/d688ec7d80bb790e6c0199a8fc0487140fc91319) | `linuxKernels.kernels.linux_xanmod: import helpers`                               |
| [`ecaaba49`](https://github.com/NixOS/nixpkgs/commit/ecaaba491d483025370857690266c953e2977941) | `linuxKernels.kernels.linux_xanmod: adjust config for 5.18`                       |
| [`61b37a0a`](https://github.com/NixOS/nixpkgs/commit/61b37a0a20413f497c78aefd38d685cfea1fd490) | `linuxKernel.kernels.linux_xanmod_latest: 5.17.8 -> 5.18.1`                       |
| [`3fd61ac5`](https://github.com/NixOS/nixpkgs/commit/3fd61ac55ec27a8eefae188ffa600d568de12067) | `linuxKernels.kernels.linux_xanmod: 5.15.40 -> 5.15.43`                           |
| [`1b467b89`](https://github.com/NixOS/nixpkgs/commit/1b467b894b7dd9c9fc6ceff3f6c7a5ce4c24555e) | `platformio: needs xdg-user-dirs`                                                 |
| [`e366bbf9`](https://github.com/NixOS/nixpkgs/commit/e366bbf9b631b3e54bc829780c4fefd3b21534ff) | `janet: 1.21.2 -> 1.22.0`                                                         |
| [`1acba8b3`](https://github.com/NixOS/nixpkgs/commit/1acba8b3e5d35eb971519785e9dce857b95cbdbc) | `psst: 2022-01-25 -> 2022-05-19 and fix build`                                    |
| [`8422c32d`](https://github.com/NixOS/nixpkgs/commit/8422c32d6903a6d34824c9fef1e51d707996db12) | `python310Packages.pycep-parser: 0.3.6 -> 0.3.7`                                  |
| [`1a82aefe`](https://github.com/NixOS/nixpkgs/commit/1a82aefed87666388380fce418f7ae0117de3fe6) | `gx: 0.14.1 -> 0.14.3 (#176176)`                                                  |
| [`e3b9cba7`](https://github.com/NixOS/nixpkgs/commit/e3b9cba7cb47ec3e09d2e2801873cc834158520e) | `xboard: pull patch pending upstream inclusion for -fno-common toolchain support` |
| [`95f00120`](https://github.com/NixOS/nixpkgs/commit/95f001206fd289959940fa1f6cc10993841818cb) | `sway: Disable strictDeps for wrapper`                                            |
| [`98fd9445`](https://github.com/NixOS/nixpkgs/commit/98fd9445717b684894fb07e415772e459b42ffc0) | `seehecht: init at 3.0.2`                                                         |
| [`fb52e287`](https://github.com/NixOS/nixpkgs/commit/fb52e287c79457f253d3e2c5647d1b8697d1b14b) | `castor: 0.8.18 -> 0.9.0`                                                         |
| [`4b88d42f`](https://github.com/NixOS/nixpkgs/commit/4b88d42f5125b6b97d4991d0f7efac95f18d90c1) | `firefox: disable 'MOZILLA_OFFICIAL=1' on i686`                                   |
| [`81008f02`](https://github.com/NixOS/nixpkgs/commit/81008f02c420a34097f2c612edf08cf298c695c5) | `ocamlPackages.menhir: 20211128 → 20220210`                                       |
| [`c25fceda`](https://github.com/NixOS/nixpkgs/commit/c25fcedaf0997809df52d9861c27d5d0d73ca932) | `liquidsoap: pin menhir dependency`                                               |
| [`1b95daa3`](https://github.com/NixOS/nixpkgs/commit/1b95daa381fa4a0963217a5d386433c20008208a) | `alt-ergo: ensure compatibility with Menhir ≥ 20211215`                           |
| [`0a91054a`](https://github.com/NixOS/nixpkgs/commit/0a91054a94cf4abab1048134cc8066d2a7db4ede) | `oacmlPackages.toml: make compatible with menhir ≥ 20211215`                      |
| [`f6f5188f`](https://github.com/NixOS/nixpkgs/commit/f6f5188f751cdb9821802eef4e5e680e758eca53) | `oacmlPackages.odate: make compatible with menhir ≥ 20211215`                     |
| [`4195c922`](https://github.com/NixOS/nixpkgs/commit/4195c9225b68c4b1d8fd883c4c18298f4c83318a) | `nitter: 2022-05-13 -> 2022-06-04`                                                |
| [`a354d5b1`](https://github.com/NixOS/nixpkgs/commit/a354d5b16bea0fe4b6790d2e078551e25f9b0d92) | `mu: 1.6.10 -> 1.6.11`                                                            |
| [`dd770cc2`](https://github.com/NixOS/nixpkgs/commit/dd770cc211b9de60c5c6bb116f0b01d608661889) | `stdenv/adapters.nix: Fix for overlay style arguments`                            |
| [`cd88f861`](https://github.com/NixOS/nixpkgs/commit/cd88f8613f3d8cd5a985c624cd3cf14459ddbed9) | `pkgs/make-derivation.nix: Refactor, hardcode mkDerivationSimple`                 |
| [`7e3c80f5`](https://github.com/NixOS/nixpkgs/commit/7e3c80f5b7db00252f3334d97a28d2c4800c8f41) | `pkgs/make-derivation.nix: Refactor, inline makeOverlayable`                      |
| [`b362ef4e`](https://github.com/NixOS/nixpkgs/commit/b362ef4eff67d5a57a87e47290b8d02e24772663) | `pipewire: Never set an empty LD_LIBRARY_PATH`                                    |
| [`1b00adba`](https://github.com/NixOS/nixpkgs/commit/1b00adbad171384b99ad842684d4f5e58e6657a2) | `pkgs/make-derivation.nix: Refactor, introduce let binding`                       |
| [`f8ffee74`](https://github.com/NixOS/nixpkgs/commit/f8ffee74ce49707a5fb3eeb612cf12c105392027) | `Revert "gst_all_1.gst-plugins-good: add missing deps for qt5Support (#176246)"`  |
| [`f0cad4fa`](https://github.com/NixOS/nixpkgs/commit/f0cad4fafc92033bc1758ceda9dc2d34d0631963) | `ookla-speedtest: support darwin`                                                 |
| [`1daf0125`](https://github.com/NixOS/nixpkgs/commit/1daf0125afd9c44723d16f6b3dad5fcbc3cde858) | `keepassxc: Wrap once`                                                            |
| [`25bcc609`](https://github.com/NixOS/nixpkgs/commit/25bcc609425328c36ee1750de90432f527238dcb) | `python310Packages.asyncssh: 2.10.1 -> 2.11.0`                                    |
| [`a001dc6e`](https://github.com/NixOS/nixpkgs/commit/a001dc6e3718c77906125470b5b8be768dfc76f1) | `ngspice: 36 -> 37`                                                               |
| [`596bd0fc`](https://github.com/NixOS/nixpkgs/commit/596bd0fcff26b7387873fa3311a5159d5c0663cf) | `libngspice: 36 -> 37`                                                            |
| [`ad539545`](https://github.com/NixOS/nixpkgs/commit/ad53954502ba38c0c9e714629e419ce5029f6981) | `python310Packages.jsonrpc-websocket: 3.1.1 -> 3.1.4`                             |
| [`4e9d1ca3`](https://github.com/NixOS/nixpkgs/commit/4e9d1ca3a423f47d588772c2dcda5db949e24e3f) | `exiftool: fix mainProgram`                                                       |
| [`f6ffa113`](https://github.com/NixOS/nixpkgs/commit/f6ffa11348108b05ecb4ade86cbefbe3099199b2) | `python310Packages.jsonrpc-async: 2.1.0 -> 2.1.1`                                 |
| [`fc6a90ab`](https://github.com/NixOS/nixpkgs/commit/fc6a90abc24f7f28a3fcdce8bd13fd4be9300c61) | `python310Packages.jsonrpc-base: 2.1.0 -> 2.1.1`                                  |
| [`686fc5d9`](https://github.com/NixOS/nixpkgs/commit/686fc5d91db1cbaeaa6fc75e8185642c9ac993c6) | `vapoursynth: 58 -> 59`                                                           |
| [`a69d42dc`](https://github.com/NixOS/nixpkgs/commit/a69d42dcfbe57ed2684a6d68cae12ae11cc69d9b) | `python310Packages.json-schema-for-humans: 0.40.2 -> 0.41.1`                      |
| [`16a4320f`](https://github.com/NixOS/nixpkgs/commit/16a4320fdf4e163aae3bce5a25a8acc616f4a4be) | `python310Packages.aeppl: disable failing test`                                   |
| [`de295b31`](https://github.com/NixOS/nixpkgs/commit/de295b31a899f25922867a3cec5ad34b2287812b) | `python310Packages.regenmaschine: 2022.05.1 -> 2022.06.0`                         |
| [`ff8bc2a5`](https://github.com/NixOS/nixpkgs/commit/ff8bc2a514b237852e67784d5e2b646a9d8576f8) | `tshark: remove reference in alias`                                               |
| [`4902f456`](https://github.com/NixOS/nixpkgs/commit/4902f456f4b4d13ab6b0c31b7ccaf9754dbe29e6) | `python310Packages.pysensibo: 1.0.15 -> 1.0.16`                                   |
| [`efe27818`](https://github.com/NixOS/nixpkgs/commit/efe278181e536b65b92aaccfc43bb848ae2d61ea) | `python310Packages.venstarcolortouch: 0.15 -> 0.16`                               |
| [`b82f6f7c`](https://github.com/NixOS/nixpkgs/commit/b82f6f7cf060fd3fc8e08065dc9928ba76f697c1) | `python310Packages.simplisafe-python: 2022.05.2 -> 2022.06.0`                     |
| [`a4873048`](https://github.com/NixOS/nixpkgs/commit/a4873048b4ab5c45f4902f841643882e9e3a7bdb) | `python310Packages.aiolookin: 0.1.0 -> 0.1.1`                                     |
| [`cf3cb3c2`](https://github.com/NixOS/nixpkgs/commit/cf3cb3c272d32eab56bcf7a7bca416c9cbbe578f) | `gst_all_1.gst-plugins-good: add missing deps for qt5Support (#176246)`           |
| [`803065a3`](https://github.com/NixOS/nixpkgs/commit/803065a3a23c9a71f2e36b117ca8b9d3d8bfd2c9) | `python310Packages.aesara: 2.6.6 -> 2.7.1`                                        |
| [`125e150c`](https://github.com/NixOS/nixpkgs/commit/125e150cd230087a782b9eabf731b7d7a6bffc20) | `python310Packages.pymc: unstable-2022-05-23 -> 4.0.0`                            |
| [`286cb295`](https://github.com/NixOS/nixpkgs/commit/286cb295af65ae8fee7cce4a518b236a46ac5b17) | `nimPackages.markdown: abdbe5e -> a661c26`                                        |
| [`053e10df`](https://github.com/NixOS/nixpkgs/commit/053e10dfbc6f1b396e955cd90ba06a643f8dcf9c) | `nixos/nitter: fix wait_for_open_port`                                            |
| [`d7848386`](https://github.com/NixOS/nixpkgs/commit/d7848386e5791ecbea187b013e16cbd114281c67) | `llvmPackages/libllvm: disable failing tests on armv7l`                           |
| [`72e40c2b`](https://github.com/NixOS/nixpkgs/commit/72e40c2bd25f4b735c167c67c5f0ed0a63f2da59) | `zsnes: add -fcommon workaround`                                                  |
| [`96515aa0`](https://github.com/NixOS/nixpkgs/commit/96515aa0c9372474cf1e862f0daf66dfa396b2be) | `python310Packages.hahomematic: 1.8.3 -> 1.8.4`                                   |
| [`74ed89f2`](https://github.com/NixOS/nixpkgs/commit/74ed89f2439f1ccc12da0517fe7a573a4143c9ed) | `noisetorch: 0.11.5 -> 0.12.0`                                                    |
| [`e8327b03`](https://github.com/NixOS/nixpkgs/commit/e8327b03848088b35c6eabc101bdb3d817dfdf8b) | `evolution-ews: 3.44.1 -> 3.44.2`                                                 |
| [`b1a7f0ab`](https://github.com/NixOS/nixpkgs/commit/b1a7f0abcdb9a5ad6469763c335ad5ad63b1dae1) | `python310Packages.mkdocs-material: 8.3.0 -> 8.3.1`                               |
| [`ceb01c3d`](https://github.com/NixOS/nixpkgs/commit/ceb01c3d4810127b6330077ab336fe3f1bfa65bd) | `mill: 0.10.3 → 0.10.4`                                                           |
| [`fa2f9199`](https://github.com/NixOS/nixpkgs/commit/fa2f9199e4551fca3a1e29e55fba1ad2de5a2ff7) | `docker-compose: remove ipaddress`                                                |
| [`6ca21e55`](https://github.com/NixOS/nixpkgs/commit/6ca21e550057edee0972141bc75773c9192ce2be) | `restic: 0.13.0 -> 0.13.1`                                                        |
| [`c9c3b196`](https://github.com/NixOS/nixpkgs/commit/c9c3b19634f35f244bb3c32ae037840deb0b9498) | `fetchMaven: set output's sourceProvenance to binaryBytecode`                     |
| [`3b445eac`](https://github.com/NixOS/nixpkgs/commit/3b445eaceacd3924e1604b48f33e49e2df8dbbff) | `treewide: set sourceProvenance for gradle-built packages`                        |
| [`3b6bc4b6`](https://github.com/NixOS/nixpkgs/commit/3b6bc4b69ca7eec695291af31d8878071e0e084d) | `treewide: set sourceProvenance for packages containing downloaded jars`          |
| [`386207e3`](https://github.com/NixOS/nixpkgs/commit/386207e312c64926cd522dd2ad790ec3bb6330b7) | `mmixware: add -fcommon workaround`                                               |
| [`d201f4c0`](https://github.com/NixOS/nixpkgs/commit/d201f4c01b62ea1301b789493b14316b792f9ba5) | `gtklp: add -fcommon workaround`                                                  |
| [`3937cc94`](https://github.com/NixOS/nixpkgs/commit/3937cc946a045d7d17ed34158f7111eef7dc3665) | `python310Packages.mypy: run tests`                                               |
| [`33dd0715`](https://github.com/NixOS/nixpkgs/commit/33dd0715aefb9df09da345d49e5222b101aec512) | `apksigner`                                                                       |
| [`985adfdd`](https://github.com/NixOS/nixpkgs/commit/985adfdd50ef7cb18b20c5a1cdb20e851fb9f56d) | `gstreamer plugins good: fix qt support`                                          |
| [`693bb5c1`](https://github.com/NixOS/nixpkgs/commit/693bb5c17d72c934d9307bc6cf655869a02fd918) | `junkie: pull upstream fix for -fno-common toolchains`                            |
| [`3ca93302`](https://github.com/NixOS/nixpkgs/commit/3ca93302d496e6c1487e7895cc55001b034b999f) | `tahoe-lafs: update meta.platforms, disable outdated test`                        |
| [`8437545f`](https://github.com/NixOS/nixpkgs/commit/8437545f81249b032b6a4fd887dbd8feeada80f0) | `python310Packages.buildbot: remove linters`                                      |
| [`fb38e46d`](https://github.com/NixOS/nixpkgs/commit/fb38e46dc19e1d36e29ab33c1646d60b75cbf338) | `python310Packages.rlp: adopt, cleanup`                                           |
| [`4c391ff1`](https://github.com/NixOS/nixpkgs/commit/4c391ff1dfd9b61823b061fa37345b30ee4983d9) | `python310Packages.hexbytes: init at 0.2.2`                                       |
| [`d5150587`](https://github.com/NixOS/nixpkgs/commit/d515058727c54474ae7b1ea79036b003d9b79615) | `python310Packages.eth-rlp: init at 0.3.0`                                        |
| [`4f8ac15c`](https://github.com/NixOS/nixpkgs/commit/4f8ac15c523a878196c9f00d9a9b3dd1fbda9e64) | `python310Packages.coincurve: init at 17.0.0`                                     |
| [`5f04e659`](https://github.com/NixOS/nixpkgs/commit/5f04e659720471f31e1908073f4ffccaec98e275) | `python310Packages.autobahn: 22.4.2 -> 22.5.1`                                    |
| [`a5985571`](https://github.com/NixOS/nixpkgs/commit/a5985571ca2026a509f1c31bcde36f35aeed907a) | `python310Packages.asn1tools: init at 0.163.0`                                    |
| [`ded90163`](https://github.com/NixOS/nixpkgs/commit/ded901634f89751c268413632323b309a1b71771) | `python310Packages.eth-keys: init at 0.4.0`                                       |
| [`98f3569f`](https://github.com/NixOS/nixpkgs/commit/98f3569f4fe8b11a462eb95ca30d83f821fd2ee1) | `python310Packages.eth-typing: adopt, cleanup`                                    |
| [`a380aae7`](https://github.com/NixOS/nixpkgs/commit/a380aae71c0dd050805a54ec2c49ed40dc383840) | `python310Packages.eth-hash: adopt, cleanup`                                      |
| [`02b136a8`](https://github.com/NixOS/nixpkgs/commit/02b136a85d5dd1cfa62e5e3efbfce01a86218d99) | `python310Packages.eth-utils: adopt, cleanup`                                     |
| [`8c400570`](https://github.com/NixOS/nixpkgs/commit/8c400570aa4407cd6294aadb659fc2d3b54f8db9) | `python310Packages.eth-keyfile: init at 0.6.0`                                    |
| [`8d1e3470`](https://github.com/NixOS/nixpkgs/commit/8d1e34700b075ec0c67b6002110627bd737f4467) | `python310Packages.eth-account: init at 0.6.1`                                    |
| [`07a12b70`](https://github.com/NixOS/nixpkgs/commit/07a12b703f6f1fed814ad48d4c3b890ef696673e) | `python310Packages.py-ecc: init at 6.0.0`                                         |
| [`2de83832`](https://github.com/NixOS/nixpkgs/commit/2de83832fbe2b314d9c9019d46c4a5542e3f154c) | `python310Packages.eth-abi: init at 3.0.0`                                        |
| [`f5bedc25`](https://github.com/NixOS/nixpkgs/commit/f5bedc25b2e35911dfe6abd55f581e485493cfe6) | `python310Packages.py-eth-sig-utils: init at 0.4.0`                               |
| [`8d5a2017`](https://github.com/NixOS/nixpkgs/commit/8d5a2017caf821fa13e129280a76ba2aeaff3c46) | `python310Packages.buildbot: fix tests`                                           |
| [`481ef8dd`](https://github.com/NixOS/nixpkgs/commit/481ef8ddd64c8bac88cfd12fbf83f6569a355b6b) | `nixosTests: Add allDrivers for development purposes`                             |
| [`7f025e2b`](https://github.com/NixOS/nixpkgs/commit/7f025e2b343a7c9fae2b76822d12449a511c2e88) | `netdata: started when service can be pinged`                                     |
| [`2272153e`](https://github.com/NixOS/nixpkgs/commit/2272153e49c52d67fe831b63a590f169928911bd) | `chromiumBeta: 103.0.5060.24 -> 103.0.5060.33`                                    |
| [`c49b3af8`](https://github.com/NixOS/nixpkgs/commit/c49b3af8b4989c9839015961fc4d8f4a0acc5075) | `opensnitch-ui: fix events table and notifications`                               |
| [`9644cda0`](https://github.com/NixOS/nixpkgs/commit/9644cda0a03a49777815ed4b6de41fe4eeb73a3b) | `pyasn: add missing databases`                                                    |
| [`9332a7c9`](https://github.com/NixOS/nixpkgs/commit/9332a7c99c0bc1ee5d4ea931c4acde70e2fd4215) | `ispc: unstable-2021-04-02 -> 1.18.0, (co-)maintain`                              |
| [`0cdcc2da`](https://github.com/NixOS/nixpkgs/commit/0cdcc2dad2ad15a53e97a6cde3cd1a70e057e4d1) | `python310Packages.autobahn: 22.3.2 -> 22.4.2`                                    |
| [`c2cc778b`](https://github.com/NixOS/nixpkgs/commit/c2cc778be6712901486d195c2095fc6f1532f286) | `libadwaita: 1.1.1 -> 1.1.2`                                                      |
| [`8187ce44`](https://github.com/NixOS/nixpkgs/commit/8187ce441044170ba8f6970e71e369a695095d0b) | `wails: 2.0.0-beta.36 -> 2.0.0-beta.37`                                           |
| [`2a750c30`](https://github.com/NixOS/nixpkgs/commit/2a750c302669a59a13d8a2a6fa038cbc6e6cb134) | `nixos/manual: Add docs on extra python packages in tests`                        |
| [`8858bf00`](https://github.com/NixOS/nixpkgs/commit/8858bf009e8ed2545205686945e64f0406dede9d) | `nixos/test-driver: add test for extraPythonPackages`                             |
| [`a99736e3`](https://github.com/NixOS/nixpkgs/commit/a99736e399c68db364485f127ae86e7ce3970f75) | `nixos/test-driver: add option to add extra python packages to test code`         |
| [`5f45f1cd`](https://github.com/NixOS/nixpkgs/commit/5f45f1cd289f0219642ae0f43f55996fdb6e246d) | `argocd: 2.3.3 -> 2.3.4`                                                          |
| [`f242b107`](https://github.com/NixOS/nixpkgs/commit/f242b1079a281e656188ea6264520b006097861b) | `python310Packages.smart-meter-texas: 0.5.0 -> 0.5.1`                             |
| [`d7432b81`](https://github.com/NixOS/nixpkgs/commit/d7432b815d0e08634d0a5e4f56f42fc18cbd38e9) | `infnoise: Also build and install tools`                                          |
| [`31cb3f99`](https://github.com/NixOS/nixpkgs/commit/31cb3f9908a31e6c3ba88b38c675f533fc0d5aae) | `infnoise: Add patch to fix build on aarch64-linux`                               |
| [`6c4bfe58`](https://github.com/NixOS/nixpkgs/commit/6c4bfe583c0bb74ff62e29bce3818654242667ad) | `nixos/infnoise: init`                                                            |
| [`d2aa5ff6`](https://github.com/NixOS/nixpkgs/commit/d2aa5ff6e7c17887fabb08aebca40f45d60b7cea) | `infnoise: unstable-2019-08-12 -> 0.3.2`                                          |
| [`81e1166b`](https://github.com/NixOS/nixpkgs/commit/81e1166bffbe792d303dac9a84fe751dc53b8d64) | `themechanger: 0.10.2 -> 0.11.0`                                                  |
| [`fc3790f9`](https://github.com/NixOS/nixpkgs/commit/fc3790f9952d21da3f3696ec2e3f03081704842a) | `mozillavpn: 2.8.0 → 2.8.3`                                                       |
| [`c9e173fe`](https://github.com/NixOS/nixpkgs/commit/c9e173fe09e33545ba936a0ee681df5200bae8f1) | `bzip3: init at 1.1.3`                                                            |
| [`d2144c1e`](https://github.com/NixOS/nixpkgs/commit/d2144c1e0cce513807d15979eb9844386cd16ccc) | `rivet: 3.1.5 -> 3.1.6`                                                           |
| [`179dd402`](https://github.com/NixOS/nixpkgs/commit/179dd402cbb2772cb8b80de3c58b21efb23ba030) | `yoda: 1.9.4 -> 1.9.5`                                                            |
| [`f88302aa`](https://github.com/NixOS/nixpkgs/commit/f88302aa1c0bc6f41cf2391605112c2c31a84290) | `mt32emu-smf2wav: 1.7.0 -> 1.8.2`                                                 |
| [`883cb64a`](https://github.com/NixOS/nixpkgs/commit/883cb64ae9d9c266bae6e19d740428505a997a66) | `mt32emu-qt: 1.9.0 -> 1.10.2`                                                     |
| [`f7db111f`](https://github.com/NixOS/nixpkgs/commit/f7db111ff081c69c77e64b1750a1bfcc63cb4b99) | `gkraken: 1.1.6 -> 1.2.0`                                                         |
| [`bff64d8e`](https://github.com/NixOS/nixpkgs/commit/bff64d8e02fa1685b6cfbbd9e2b980f36ffd60f6) | `libmt32emu: 2.5.3 -> 2.6.3`                                                      |
| [`d6b756de`](https://github.com/NixOS/nixpkgs/commit/d6b756dec558672fca372b1e261ed0e813c1091d) | `jabcode: unstable-2020-05-13 -> unstable-2021-02-16`                             |
| [`f9e2c544`](https://github.com/NixOS/nixpkgs/commit/f9e2c5443cf6072546b7d9ee7231dcc829a01d7f) | `prusa-slicer: use patched wxWidgets`                                             |
| [`8b5d305e`](https://github.com/NixOS/nixpkgs/commit/8b5d305e7c09f107fcfe85eacc209e4e9c729012) | `olm: 3.2.10 -> 3.2.11`                                                           |
| [`680b1632`](https://github.com/NixOS/nixpkgs/commit/680b1632a609d5e7f128c445a382486ca106800a) | `python3Packages.sfepy: 2021.4 -> 2022.1`                                         |
| [`d4e1e79e`](https://github.com/NixOS/nixpkgs/commit/d4e1e79ede9de45145eb77358aeb607d6cf7c5c3) | `xrootd: add voms support`                                                        |
| [`9e18a59e`](https://github.com/NixOS/nixpkgs/commit/9e18a59e42783bea55742e244b5185df55291bcb) | `voms: init at 2021-05-04`                                                        |