### PR TITLE
chore(flake/nvim-treesitter-src): `e4df4228` -> `26abd5fc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -692,11 +692,11 @@
     "nvim-treesitter-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654358039,
-        "narHash": "sha256-rlIQBWzkGstO6yRkCCjdL1MVjAKXT8Hsi++/1FF49sw=",
+        "lastModified": 1654427641,
+        "narHash": "sha256-x49zh8LVhi50ZbkoGsaV0qvWQH7/YWkpyX1Ruqexxdg=",
         "owner": "nvim-treesitter",
         "repo": "nvim-treesitter",
-        "rev": "e4df4228b7c07f98e55345b40ac0093d27d0d18c",
+        "rev": "26abd5fc328624bd4208bf5fd733ab6e2fa677c9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                           | Commit Message                                                                   |
| ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`26abd5fc`](https://github.com/nvim-treesitter/nvim-treesitter/commit/26abd5fc328624bd4208bf5fd733ab6e2fa677c9) | `Update lockfile.json`                                                           |
| [`8aeb7ad5`](https://github.com/nvim-treesitter/nvim-treesitter/commit/8aeb7ad5dc55f8532578211e749261e491b116e9) | `make ft_to_lang work for csharp (#2989)`                                        |
| [`8112d9bc`](https://github.com/nvim-treesitter/nvim-treesitter/commit/8112d9bc90011c368761f5b0b1945ed9a7798838) | `Update lockfile.json`                                                           |
| [`b3984030`](https://github.com/nvim-treesitter/nvim-treesitter/commit/b39840302cd35bca9e2dec1a25263737b8efa205) | `injections(ecma): add injection for commented graphql template strings (#2987)` |