### PR TITLE
chore(flake/nixpkgs-master): `66172026` -> `9c7fe48d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1654487477,
-        "narHash": "sha256-xUmOrDNzQFpPMnEdHO5EOuj4PWz5JKCon9wBXO265og=",
+        "lastModified": 1654495126,
+        "narHash": "sha256-2J7ZqdMrH5ICVJHv/6L7bRQDKudbnSBZZUzy+ZT6jjE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "66172026e025bfdf08d5be4f9b8d5be9b70f912f",
+        "rev": "9c7fe48d8d790de036d47a0288abf3dde40ded21",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`9c7fe48d`](https://github.com/NixOS/nixpkgs/commit/9c7fe48d8d790de036d47a0288abf3dde40ded21) | `python310Packages.twitchapi: 2.5.3 -> 2.5.4`    |
| [`4ffef834`](https://github.com/NixOS/nixpkgs/commit/4ffef8340888dd5c4b7dc748456071e544cca428) | `docker-compose: add $out/bin symlink`           |
| [`b7b91880`](https://github.com/NixOS/nixpkgs/commit/b7b91880d3f2358a5eacb31476ab937c0df5562a) | `docker-compose: default to v2`                  |
| [`d8cdbde2`](https://github.com/NixOS/nixpkgs/commit/d8cdbde2c94345441235bad1d473b01ec14ca011) | `terraform-providers: update 2022-06-06`         |
| [`046d0253`](https://github.com/NixOS/nixpkgs/commit/046d0253aa88e47e4d424e02bc548897d5eeacfe) | `python310Packages.safety: improve expression`   |
| [`d3d975f7`](https://github.com/NixOS/nixpkgs/commit/d3d975f71c4a038984286d3b25fe964125e80bad) | `igraph: 0.9.8 -> 0.9.9`                         |
| [`e9f4412e`](https://github.com/NixOS/nixpkgs/commit/e9f4412eb44c543b12bd8dc472ecb953b3aa2f34) | `docker-edge: remove`                            |
| [`a60358be`](https://github.com/NixOS/nixpkgs/commit/a60358bec9b6f89e7ed727c1d88336d8f0379ea1) | `kubernetes: drop obsolete workarounds`          |
| [`f2352bb5`](https://github.com/NixOS/nixpkgs/commit/f2352bb589b787cf9786de0e9c353b218410697e) | `gradio: remove`                                 |
| [`bde65d2e`](https://github.com/NixOS/nixpkgs/commit/bde65d2eea592dc1860347e5df74127e262e7844) | `tootle: pin to vala 0.54`                       |
| [`ffc97215`](https://github.com/NixOS/nixpkgs/commit/ffc97215641cd5c240a2edbd95f415432a36198e) | `perlPackages.IPCConcurrencyLimit: init at 0.17` |
| [`c79cc67b`](https://github.com/NixOS/nixpkgs/commit/c79cc67bdb77fe442dafd863b68492859f3ccec7) | `perlPackages.ArrayRefElem: init at 1.00`        |