### PR TITLE
chore(flake/nvim-treesitter-context-src): `a7916523` -> `026e6f40`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
     "nvim-treesitter-context-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1652363724,
-        "narHash": "sha256-4TsnUDakK13xrhJc+vB8JHZGHPReK7rmKzhfdH0YDF8=",
+        "lastModified": 1654888184,
+        "narHash": "sha256-uoRUqB6rEU8j0MjwrKL3vWFzySCg5PHZBuNqWaziGZc=",
         "owner": "romgrk",
         "repo": "nvim-treesitter-context",
-        "rev": "a7916523e8107a57021cabae51917b7dae844aa6",
+        "rev": "026e6f407d41f0f8229c067b0a2a19c6ab26bdae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                                   | Commit Message                             |
| ------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
| [`026e6f40`](https://github.com/nvim-treesitter/nvim-treesitter-context/commit/026e6f407d41f0f8229c067b0a2a19c6ab26bdae) | `feat: add config.mode (#120)`             |
| [`81116dc0`](https://github.com/nvim-treesitter/nvim-treesitter-context/commit/81116dc03abf35ca99c7910f9f779961042dea12) | `fix: truncate outer context lines (#123)` |
| [`0804542f`](https://github.com/nvim-treesitter/nvim-treesitter-context/commit/0804542f61adfa4598020f203c6f28349c112c42) | `feat: add config.separator`               |
| [`27a0e2a8`](https://github.com/nvim-treesitter/nvim-treesitter-context/commit/27a0e2a8eeea7887b5584c0b041f3d72e448fcc1) | `feat: add config.multiline_threshold`     |