### PR TITLE
chore(flake/null-ls-nvim-src): `1b777bc3` -> `dfdd5fab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -580,11 +580,11 @@
     "null-ls-nvim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654041249,
-        "narHash": "sha256-lsLrXVkg4XQvqZyq/pTEAB8Ik+y+6YiGkWyVOF4wPGE=",
+        "lastModified": 1654915948,
+        "narHash": "sha256-ekawl6TREZ7Vxc3r3vjjmNzxMvcXNjNi45T3WyYg3ps=",
         "owner": "jose-elias-alvarez",
         "repo": "null-ls.nvim",
-        "rev": "1b777bc360062659189fcf0136892759ed0aadda",
+        "rev": "dfdd5fab3c53c30f83c78ea351b9a8f65715a5b7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                           | Commit Message                                               |
| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`dfdd5fab`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/dfdd5fab3c53c30f83c78ea351b9a8f65715a5b7) | `add severities for common flake8 plugins (#906)`            |
| [`7540baa0`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/7540baa0d5ca766a1958bb44c235dce990d98ce1) | `Support XDG_RUNTIME_DIR for temp_files (#899)`              |
| [`d0e360cc`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/d0e360cc17b7848a0ecb1f326c6789707f819771) | `chore: autogen metadata and docs`                           |
| [`697491ed`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/697491edfbd21918b9cdead580f230d11e01cc91) | `Add sql-formatter (#905)`                                   |
| [`5d5cba15`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/5d5cba15594c1b093a2177b339f34b3e3468fb46) | `chore: autogen metadata and docs`                           |
| [`fc1abe2b`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/fc1abe2b6748847cf8e377594eebd414ba7056ae) | `feat: added cfn-lint diagnostics (#901)`                    |
| [`474372a8`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/474372a8e553b336b1039a1060b4c07a5f6ac03e) | `chore: autogen metadata and docs`                           |
| [`438c08cf`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/438c08cfe5452cac9dbd8901fbea5b62193567dd) | `feat: add cuda support for clang-format (#898)`             |
| [`b5b5f5e1`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/b5b5f5e151f82b7d572e63021dbb46a909fb8dc6) | `fix(builtins): handle mypy diagnostics without code (#897)` |