### PR TITLE
chore(flake/nixpkgs): `c5d810f4` -> `3f909fb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -464,11 +464,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654398695,
-        "narHash": "sha256-Kw/KeoFXszNsF5mORP45mrxCP+k9Aq03hWcuWCL9sdI=",
+        "lastModified": 1654875595,
+        "narHash": "sha256-Vairke3ryPSFpgQdaYicPPhPWMGhtzm6V+1uF2Tefbk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5d810f4c74c824ae0fb788103003c6c9d366a08",
+        "rev": "3f909fb574d9b9d7294e544981c62a4a5e4599fc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`936239f6`](https://github.com/NixOS/nixpkgs/commit/936239f665401a97be3832ce69eec06ff35cc5de) | `tracker-miners: 3.3.0 → 3.3.1`                                                                      |
| [`9a71f92d`](https://github.com/NixOS/nixpkgs/commit/9a71f92d96c26481fed33ced58a1c75f1c030fde) | `tepl: 6.0.1 → 6.0.2`                                                                                |
| [`b0124395`](https://github.com/NixOS/nixpkgs/commit/b01243956733805b34cf131d806c21f84cf7f4f1) | `networkmanagerapplet: 1.26.0 → 1.28.0`                                                              |
| [`559dae14`](https://github.com/NixOS/nixpkgs/commit/559dae140f92a090b648d88392874a020f1e9d0b) | `gupnp-av: 0.14.0 → 0.14.1`                                                                          |
| [`497b4af9`](https://github.com/NixOS/nixpkgs/commit/497b4af9f04f237cb53f5def57790b44d9ea4fac) | `gnome-desktop: 42.1 → 42.2`                                                                         |
| [`67de7b4e`](https://github.com/NixOS/nixpkgs/commit/67de7b4eb28d61fc301a83d1d98cc2970720eb78) | `gnome.gnome-bluetooth: 42.0 → 42.1`                                                                 |
| [`835b46f0`](https://github.com/NixOS/nixpkgs/commit/835b46f081e6022cc5036a215329c257155d6d3b) | `amtk: 5.4.0 → 5.4.1`                                                                                |
| [`35c7173c`](https://github.com/NixOS/nixpkgs/commit/35c7173cf5392522d632cb6469298e1e73360929) | `apacheHttpd: 2.4.53 -> 2.4.54`                                                                      |
| [`f9c45cdd`](https://github.com/NixOS/nixpkgs/commit/f9c45cdd685554aac9b64f8afeb2991b1cf38652) | `sile: 0.12.5 → 0.13.0 (#177079)`                                                                    |
| [`33d84e02`](https://github.com/NixOS/nixpkgs/commit/33d84e02ee99fbb5254ad0daadfdc5ddad1d4241) | `xdgmenumaker: 1.5 -> 1.6 (#176568)`                                                                 |
| [`66756aea`](https://github.com/NixOS/nixpkgs/commit/66756aeab9f783d1c1dc3f70257b6f005992dfcc) | `php80Packages.composer: 2.3.5 -> 2.3.7`                                                             |
| [`5d890c08`](https://github.com/NixOS/nixpkgs/commit/5d890c086aa288a7dd93f1de87573391d2e82717) | `php81: 8.1.6 -> 8.1.7`                                                                              |
| [`24e9824d`](https://github.com/NixOS/nixpkgs/commit/24e9824ddbe1e065f0582f0aabbb56dd3aef5d93) | `php80: 8.0.19 -> 8.0.20`                                                                            |
| [`d9e71531`](https://github.com/NixOS/nixpkgs/commit/d9e71531a0ed03d296e56dd38f5f1864a55c64c1) | `lib/modules: Fix missing prefix in extendModules when unset in both eval- and extend-`              |
| [`d9b980c9`](https://github.com/NixOS/nixpkgs/commit/d9b980c98e218658d365482265fe4ac8fcacf130) | `linux: enable vc4 HDMI-CEC by default (#176762)`                                                    |
| [`f6af6472`](https://github.com/NixOS/nixpkgs/commit/f6af64726754c634b619e1d24d58acb1e464652e) | `python310Packages.exceptiongroup: 1.0.0rc7 -> 1.0.0rc8`                                             |
| [`3d019eaf`](https://github.com/NixOS/nixpkgs/commit/3d019eaff7caca6610db913726f89223787e370d) | `python310Packages.fpyutils: 2.1.0 -> 2.2.0`                                                         |
| [`73238a42`](https://github.com/NixOS/nixpkgs/commit/73238a4242568596f5cb89fa845c094a19e81bb0) | `buildkite-test-collector-rust: fix vendor sha`                                                      |
| [`9632bc06`](https://github.com/NixOS/nixpkgs/commit/9632bc06aeadd1265d454f8f7068775ed2ab46a4) | ``buildkite-test-collector-rust: init at version `0.1.0` (#176118)``                                 |
| [`18ad5579`](https://github.com/NixOS/nixpkgs/commit/18ad5579c4fd3dbb4dbc864a5d11ab8eeffbd6a5) | `mmc-utils: clarify license`                                                                         |
| [`0d504876`](https://github.com/NixOS/nixpkgs/commit/0d5048765fa2f9a266f6e743b3a6e0769783dd79) | `mmc-utils: enable parallel building`                                                                |
| [`77d0ed11`](https://github.com/NixOS/nixpkgs/commit/77d0ed11f6e13f08837972cac7833ff20680801e) | `mmc-utils: don't manually run make`                                                                 |
| [`dc08e07e`](https://github.com/NixOS/nixpkgs/commit/dc08e07e7c40f3fe6b704ed58fcc178a5a92602e) | `mmc-utils: 2021-05-11 -> unstable-2022-04-26`                                                       |
| [`0bbe5103`](https://github.com/NixOS/nixpkgs/commit/0bbe51030e6e891c012ed251053c038cff27eeb6) | `mmc-utils: fetchgit -> fetchzip`                                                                    |
| [`134b8fc0`](https://github.com/NixOS/nixpkgs/commit/134b8fc0d49a2fd1e3f5aeb8f207a02ae38438fe) | `mmc-utils: update homepage and src URL`                                                             |
| [`6130c92d`](https://github.com/NixOS/nixpkgs/commit/6130c92db65606145f7d7f869f08f59f37af5edf) | `retroarchBare: add -fcommon workaround`                                                             |
| [`ab4e0fc1`](https://github.com/NixOS/nixpkgs/commit/ab4e0fc110eb4850da9eb410d0d81920641b7456) | `python310Packages.pulumi-aws: use sourceRoot`                                                       |
| [`31042291`](https://github.com/NixOS/nixpkgs/commit/310422912295630de7f752bc7c12af3c9905ab03) | `checkov: 2.0.1206 -> 2.0.1209`                                                                      |
| [`e6a8399c`](https://github.com/NixOS/nixpkgs/commit/e6a8399cafcadd3f44e59db8487d9ee44190e727) | `python310Packages.bc-python-hcl2: 0.3.42 -> 0.3.43`                                                 |
| [`f905d9d9`](https://github.com/NixOS/nixpkgs/commit/f905d9d9bde4eddd3c3e0ae917df45a857cf207b) | `n8n: 0.181.0 → 0.181.2`                                                                             |
| [`0aa9eac9`](https://github.com/NixOS/nixpkgs/commit/0aa9eac9c95310dc627e0d763475fb1e16d4b3d6) | `python310Packages.svg-path: 6.0 -> 6.1`                                                             |
| [`a5f36314`](https://github.com/NixOS/nixpkgs/commit/a5f36314c769d8df0321b3b84d642d15c9bbcaf3) | `python310Packages.transformers: 4.19.2 -> 4.19.3`                                                   |
| [`a824be79`](https://github.com/NixOS/nixpkgs/commit/a824be79d863add368b73d7d444745f9913f1076) | `python310Packages.types-freezegun: 1.1.9 -> 1.1.10`                                                 |
| [`4b4376cd`](https://github.com/NixOS/nixpkgs/commit/4b4376cded662b1430e5afad7ee03e4e3fe2cf07) | `python310Packages.trimesh: 3.12.5 -> 3.12.6`                                                        |
| [`6667e367`](https://github.com/NixOS/nixpkgs/commit/6667e3670fcbdc5f4c8a5b29601f48035f922e67) | `pantheon.elementary-notifications: 6.0.1 -> 6.0.2`                                                  |
| [`22e80680`](https://github.com/NixOS/nixpkgs/commit/22e8068097cf022d8f2d212d3f8b2a7ebfb6c035) | `pantheon.elementary-videos: 2.8.3 -> 2.8.4`                                                         |
| [`63eead4a`](https://github.com/NixOS/nixpkgs/commit/63eead4a4fa5f3bc65323dd79628d2b2e9cd74ef) | `python310Packages.pynetgear: 0.10.4 -> 0.10.5`                                                      |
| [`1de09605`](https://github.com/NixOS/nixpkgs/commit/1de09605f2e0fc36f8c65fc49449138ffa7b6fd0) | `python310Packages.peaqevcore: 0.3.4 -> 0.3.14`                                                      |
| [`a7b8b68b`](https://github.com/NixOS/nixpkgs/commit/a7b8b68ba96dbcead84b6a630c79ef01bf9f0586) | `python310Packages.twitchapi: 2.5.4 -> 2.5.5`                                                        |
| [`19e8b063`](https://github.com/NixOS/nixpkgs/commit/19e8b063a968b4d8e25f2f9edaf78808f7503e19) | `python310Packages.pyrogram: 2.0.26 -> 2.0.27`                                                       |
| [`8bc1f617`](https://github.com/NixOS/nixpkgs/commit/8bc1f617dd3e1faa2d55d80d06895bb5a08aea0b) | `squeak: add -fcommon workaround`                                                                    |
| [`3f953478`](https://github.com/NixOS/nixpkgs/commit/3f953478bee6771a8ce5c86540b1fda451df1808) | `unvanquished: use SRI hash format`                                                                  |
| [`2275593f`](https://github.com/NixOS/nixpkgs/commit/2275593fe8a3c577ddf79c46207cfefa7a0f5133) | `openttd/nml.nix: use SRI hash format`                                                               |
| [`3b224dcc`](https://github.com/NixOS/nixpkgs/commit/3b224dccc3306043d1f7ee4dc1229a95e464d665) | `zoom: use SRI hash format`                                                                          |
| [`ce51fe80`](https://github.com/NixOS/nixpkgs/commit/ce51fe80f8e91b1dec219d21f3184cfad30087cc) | `zdoom: use SRI hash format`                                                                         |
| [`95390a3e`](https://github.com/NixOS/nixpkgs/commit/95390a3e1334421e67e44343ab33caf70b6ee7af) | `zandronum/sqlite.nix: use SRI hash format`                                                          |
| [`494ef5a6`](https://github.com/NixOS/nixpkgs/commit/494ef5a68c632cc24f68c78ce9dd2e51945a62cb) | `vectoroids: use SRI hash format`                                                                    |
| [`5b6c9db8`](https://github.com/NixOS/nixpkgs/commit/5b6c9db8109797eece80a590890107e8aa744b21) | `performous: use SRI hash format`                                                                    |
| [`8e41788c`](https://github.com/NixOS/nixpkgs/commit/8e41788cba33409cf2e1113b14cc7b19f97f5adf) | `leela-zero: use SRI hash format`                                                                    |
| [`d2ebaafd`](https://github.com/NixOS/nixpkgs/commit/d2ebaafd9081c26a5da581898e562b348ecf4a95) | `koules: use SRI hash format`                                                                        |
| [`e28fc76d`](https://github.com/NixOS/nixpkgs/commit/e28fc76d2cdb785ef46c8fe0344bb5a814ad83d0) | `julius: use SRI hash format`                                                                        |
| [`0036078a`](https://github.com/NixOS/nixpkgs/commit/0036078a21f199a0a17e4a0e66928986fd52cf26) | `gshogi: use SRI hash format`                                                                        |
| [`1404529e`](https://github.com/NixOS/nixpkgs/commit/1404529e1dfc07bf4bc163fe9d131ffffa65e858) | `fairymax: use SRI hash format`                                                                      |
| [`233e380f`](https://github.com/NixOS/nixpkgs/commit/233e380f3b09efc4fb67d80898a59e494c1b6baa) | `tworld2: use SRI hash format`                                                                       |
| [`2922710c`](https://github.com/NixOS/nixpkgs/commit/2922710cb57981ac90f09d66791c6637bbb0e1e7) | `otto-matic: use SRI hash format`                                                                    |
| [`bdbfd5ce`](https://github.com/NixOS/nixpkgs/commit/bdbfd5cead25a9bacdd956a41a2df666626124ce) | `whitebox-tools: use SRI hash format`                                                                |
| [`0965a514`](https://github.com/NixOS/nixpkgs/commit/0965a514043a76f4495ae564a9a669f5db4ccf08) | `udig: use SRI hash format`                                                                          |
| [`254a8238`](https://github.com/NixOS/nixpkgs/commit/254a82389d1e6ec2bb4b25673f361d6bd57bdfc0) | `openorienteering-mapper: use SRI hash format`                                                       |
| [`8f3e98cf`](https://github.com/NixOS/nixpkgs/commit/8f3e98cf282fa02879a7d10cb9f8ebe0b5ed8deb) | `bugdom: use SRI hash format`                                                                        |
| [`96188399`](https://github.com/NixOS/nixpkgs/commit/96188399399fda479dd75a6263283385f4e035ff) | `gnome-todo: use SRI hash format`                                                                    |
| [`3ddf13a6`](https://github.com/NixOS/nixpkgs/commit/3ddf13a66e06427a87f1105233ebc49fa0fe4ce7) | `deno: 1.22.2 -> 1.22.3`                                                                             |
| [`056e7bc9`](https://github.com/NixOS/nixpkgs/commit/056e7bc946cf931bc6d69cebb84b0b4b284744af) | `clojure: 1.11.1.1113 -> 1.11.1.1119`                                                                |
| [`3abb144e`](https://github.com/NixOS/nixpkgs/commit/3abb144ebf3b2e18c8ef8a80ca7265628054d241) | `python310Packages.sunpy: 4.0.0 -> 4.0.1`                                                            |
| [`df118d7a`](https://github.com/NixOS/nixpkgs/commit/df118d7a7a3fbe365673be84d54bf400c6dbb3a9) | `vscode: 1.67.2 -> 1.68.0`                                                                           |
| [`1d8b8365`](https://github.com/NixOS/nixpkgs/commit/1d8b8365a02efbf668311dc9db06cb98d49e7302) | `oksh: 7.0 -> 7.1`                                                                                   |
| [`660ac5bf`](https://github.com/NixOS/nixpkgs/commit/660ac5bf602ae820a3239842e292a8b168b952f9) | `pythonPackages.asf_search: init at 3.0.6 (#157504)`                                                 |
| [`c55d70a2`](https://github.com/NixOS/nixpkgs/commit/c55d70a21ac01de93a2d3da2330b93d6d46d251f) | `python310Packages.pikepdf: 5.1.3 -> 5.1.4`                                                          |
| [`99fcf0ee`](https://github.com/NixOS/nixpkgs/commit/99fcf0ee74957231ff0471228e9a59f976a0266b) | `subversion: enable darwin keychain support (#176730)`                                               |
| [`559ee726`](https://github.com/NixOS/nixpkgs/commit/559ee726a62f58fd85ad24b641c86bfa5214bf52) | `gh: 2.12.0 -> 2.12.1`                                                                               |
| [`f063970e`](https://github.com/NixOS/nixpkgs/commit/f063970e50f9c8460398988c0fe3b3e96082c8eb) | `nixos/podman: add user socket/service`                                                              |
| [`6400298c`](https://github.com/NixOS/nixpkgs/commit/6400298c786d57018a6e1d75abb26ff00861f5c2) | `python310Packages.pywizlight: 0.5.13 -> 0.5.14`                                                     |
| [`fc909087`](https://github.com/NixOS/nixpkgs/commit/fc909087cc3386955f21b4665731dbdaceefb1d8) | `polychromatic: init at 0.7.3 (#176932)`                                                             |
| [`f84dbdd7`](https://github.com/NixOS/nixpkgs/commit/f84dbdd78eba7a7bf955086180d223c60240a229) | `apc-temp-fetch: init at 0.0.1`                                                                      |
| [`805007dc`](https://github.com/NixOS/nixpkgs/commit/805007dc7dd97b985925c17c0c50282ffda4c4fa) | `dagger: 0.2.12 -> 0.2.18`                                                                           |
| [`b64c3d38`](https://github.com/NixOS/nixpkgs/commit/b64c3d388590b72172b90cf4a58e70251d306599) | `arrow-cpp: pin jemalloc tarball (#177037)`                                                          |
| [`f3d9f4f1`](https://github.com/NixOS/nixpkgs/commit/f3d9f4f15a8d001234913aff26461a090c5ab3d4) | `vimPlugins.alpha-nvim: init at 2022-04-22 (#177049)`                                                |
| [`d3a5201b`](https://github.com/NixOS/nixpkgs/commit/d3a5201bb52b07c9243ff01810b81b8c1d22ef74) | `python310Packages.google-cloud-spanner: 3.14.0 -> 3.14.1`                                           |
| [`29ccd797`](https://github.com/NixOS/nixpkgs/commit/29ccd79723d1e7da58a49338a13954cd98574226) | `python310Packages.google-cloud-monitoring: 2.9.1 -> 2.9.2`                                          |
| [`b7b4b839`](https://github.com/NixOS/nixpkgs/commit/b7b4b839bbcf62332a3a8aaec81d66cc1afa6060) | `python310Packages.pulumi-aws: 5.3.0 -> 5.7.2`                                                       |
| [`430a00d8`](https://github.com/NixOS/nixpkgs/commit/430a00d89ffe6f664fd724161fbc82e79ac93ecb) | `python310Packages.google-cloud-datastore: 2.6.2 -> 2.7.0`                                           |
| [`519e07b2`](https://github.com/NixOS/nixpkgs/commit/519e07b2970ccdc1f4a458b1e02f184db1cb79a5) | `nodePackages.graphql-language-service-cli: init at 3.2.26`                                          |
| [`55a12775`](https://github.com/NixOS/nixpkgs/commit/55a127751df8523630842aeef487588648044524) | `golangci-lint: only mark broken for x86_64 on darwin`                                               |
| [`64f51859`](https://github.com/NixOS/nixpkgs/commit/64f51859cb532e377645aaa20a59eca86a2f9b8d) | `python310Packages.google-cloud-automl: 2.7.2 -> 2.7.3`                                              |
| [`841cd68a`](https://github.com/NixOS/nixpkgs/commit/841cd68a2c05303b558583cfd85de0c58c044add) | `tmux: 3.3 -> 3.3a`                                                                                  |
| [`00a46966`](https://github.com/NixOS/nixpkgs/commit/00a46966be0fabae642a3d035529d984e56cfa03) | `lib/zip-int-bits: fix typo: bitXOR -> bitXor`                                                       |
| [`1c5daefe`](https://github.com/NixOS/nixpkgs/commit/1c5daefee97d23b629e54d9a7b0e2590b8bbebe4) | `yubikey-manager: relax fido2 version constraint`                                                    |
| [`8f855704`](https://github.com/NixOS/nixpkgs/commit/8f855704cc9ef07d2a1544423ab40fdf93f47a96) | `python310Packages.onlykey-solo-python: make compatible with fido2 1.0.0`                            |
| [`d0a614a2`](https://github.com/NixOS/nixpkgs/commit/d0a614a2f8f6269350293c9ed746c816b19b31fa) | `python310Packages.keyring: 23.5.1 -> 23.6.0`                                                        |
| [`f38fd469`](https://github.com/NixOS/nixpkgs/commit/f38fd4699273f0182cf6bc97a231877d0036959e) | `cachix-agent: set USER to please cachix`                                                            |
| [`c316b173`](https://github.com/NixOS/nixpkgs/commit/c316b173621e769b214abed66516489cccb2b63e) | `python310Packages.db-dtypes: add format`                                                            |
| [`845ea17b`](https://github.com/NixOS/nixpkgs/commit/845ea17bc9b1bd31e5f2524ad663f21dc338c98f) | `python310Packages.ormar: 0.11.0 -> 0.11.1`                                                          |
| [`85f2a13e`](https://github.com/NixOS/nixpkgs/commit/85f2a13ee37459cb9c01ef19bb8dd9e0a34686c3) | `check that password is not blank`                                                                   |
| [`9ce89405`](https://github.com/NixOS/nixpkgs/commit/9ce8940590f2517a3ca6b6998cc07e9b94fe28f9) | `python310Packages.db-dtypes: 1.0.1 -> 1.0.2`                                                        |
| [`ce77121c`](https://github.com/NixOS/nixpkgs/commit/ce77121c7673e999a6777a58eae8d8c005530bf2) | `kotlin-native: 1.6.21 → 1.7.0`                                                                      |
| [`3060e296`](https://github.com/NixOS/nixpkgs/commit/3060e296ca5a5aec1834d2f5087a125626134f44) | `kotlin: 1.6.21 → 1.7.0`                                                                             |
| [`355928d0`](https://github.com/NixOS/nixpkgs/commit/355928d0309a4840065ac06bd66f9cf22f2902c2) | `manuskript: remove steveej as a maintainer`                                                         |
| [`cc550b68`](https://github.com/NixOS/nixpkgs/commit/cc550b680113785f8a13597073c27a658c91a857) | `easyeffects: 6.2.4 → 6.2.5`                                                                         |
| [`6850695d`](https://github.com/NixOS/nixpkgs/commit/6850695d67d7eb22706554af02e40f0eabb6af88) | `fx_cast: 0.1.2 -> 0.2.0`                                                                            |
| [`5ad7773c`](https://github.com/NixOS/nixpkgs/commit/5ad7773cdac70d05c341a187f9a77fe044b9d7be) | `todoman: disable failing test and unmark broken for darwin`                                         |
| [`0d2ee36c`](https://github.com/NixOS/nixpkgs/commit/0d2ee36cf3d5bb93a57d9e119be108b784ce71b9) | `rekor-cli, rekor-server: 0.7.0 -> 0.8.0`                                                            |
| [`d8521f40`](https://github.com/NixOS/nixpkgs/commit/d8521f4005de7822cd04a8a6c04ca9e8493c18df) | `gogs: 0.12.6 -> 0.12.9`                                                                             |
| [`d0a9445a`](https://github.com/NixOS/nixpkgs/commit/d0a9445a29223344aeaf3977d9974825709d7438) | `python310Packages.google-cloud-storage: 2.3.0 -> 2.4.0`                                             |
| [`944ed09d`](https://github.com/NixOS/nixpkgs/commit/944ed09de6050dc4b7e6e7878acc39a1b313bae9) | `alarm-clock-applet: pull fix pending upstream inclusion for -fno-common toolchains`                 |
| [`368a80ec`](https://github.com/NixOS/nixpkgs/commit/368a80ecd8fc7d842b7e923a7a563fe105251b36) | `runc: 1.1.2 -> 1.1.3`                                                                               |
| [`4f1a48de`](https://github.com/NixOS/nixpkgs/commit/4f1a48de231f3edc5b5fbc3a8d4132343775f6a2) | `python310Packages.regenmaschine: 2022.06.0 -> 2022.06.1`                                            |
| [`9fc3b49d`](https://github.com/NixOS/nixpkgs/commit/9fc3b49dd0b0229d25d27fa484f07b69cd4baa82) | `python310Packages.huum: 0.5.0 -> 0.6.0`                                                             |
| [`9ed9ea16`](https://github.com/NixOS/nixpkgs/commit/9ed9ea16afb31c59d8bebe1eb3b326962425bf03) | `python3Packages.black: disable all tests on aarch64-linux`                                          |
| [`11491d86`](https://github.com/NixOS/nixpkgs/commit/11491d868893e8301c057d1f66881b53791b399e) | `checkov: 2.0.1204 -> 2.0.1206`                                                                      |
| [`725f61a2`](https://github.com/NixOS/nixpkgs/commit/725f61a214ff66ee7dd8e23eaf17975cbec7d64d) | `haste-server: 9e921d59098c1093050201942f71d357fa89ffee -> 787d839086faee0b55c76ce5944fa207d22e85b4` |
| [`f954e8ac`](https://github.com/NixOS/nixpkgs/commit/f954e8acd71b179652976008ff5c10cfd8bbc333) | `python3Packages.black: disable another test on aarch64-linux`                                       |
| [`c91cec75`](https://github.com/NixOS/nixpkgs/commit/c91cec755b43876e70406aff16760f6cacdabe77) | `python310Packages.stripe: 3.2.0 -> 3.3.0`                                                           |
| [`c54c71b4`](https://github.com/NixOS/nixpkgs/commit/c54c71b4ecbff6873435bb60d484ab4d63bad620) | `n8n: fix test`                                                                                      |
| [`19e3b46c`](https://github.com/NixOS/nixpkgs/commit/19e3b46c6eb11eaf9b6c89011974234e9e2e19a4) | `python310Packages.vertica-python: 1.0.5 -> 1.1.0`                                                   |
| [`fe5ff7c4`](https://github.com/NixOS/nixpkgs/commit/fe5ff7c413bb1bb121638334df5d32262e2a033d) | `n8n: 0.179.0 → 0.181.0`                                                                             |
| [`2f042618`](https://github.com/NixOS/nixpkgs/commit/2f0426187c466483916c5060fa28c60b67d23cff) | `fluxcd: 0.31.0 -> 0.31.1`                                                                           |
| [`42550027`](https://github.com/NixOS/nixpkgs/commit/42550027d89ce743b1c104cbf2a192d059186b92) | `treewide: remove references to nodejs-10_x`                                                         |
| [`97d05d24`](https://github.com/NixOS/nixpkgs/commit/97d05d24b60dfbdb48b45fc02f95a3afe60cb0aa) | `Revert "nodejs-16_x: 16.15.0 -> 16.15.1"`                                                           |
| [`62406f02`](https://github.com/NixOS/nixpkgs/commit/62406f02f75b51b0fe9a201b6b213e8fb6244147) | `emacs.pkgs.melpa-packages: 2022-06-09`                                                              |
| [`d62acd22`](https://github.com/NixOS/nixpkgs/commit/d62acd223d04c083e47c1546ad2647efd9a531f6) | `elpa-generated.nix manual fixup`                                                                    |
| [`6e2f03ef`](https://github.com/NixOS/nixpkgs/commit/6e2f03ef9fccb613df3534d92fed73702402a550) | `elpa-packages 2022-06-09`                                                                           |
| [`b8b59073`](https://github.com/NixOS/nixpkgs/commit/b8b59073da495bb4e7ba8daa9dcd683343abbd9f) | `nongnu-packages 2022-06-09`                                                                         |
| [`72b895f7`](https://github.com/NixOS/nixpkgs/commit/72b895f7e3c05a2252325c7a284e6e3e52416e1b) | `python310Packages.peaqevcore: 0.2.0 -> 0.3.4`                                                       |
| [`1145d321`](https://github.com/NixOS/nixpkgs/commit/1145d3215501c45ef491d1979ef98d94555b14eb) | `python310Packages.rollbar: 0.16.2 -> 0.16.3`                                                        |
| [`e3aa43fd`](https://github.com/NixOS/nixpkgs/commit/e3aa43fd2380c42e7fc7f3ca1a95df765a3cafa2) | `python3Packages.pulumi: fix the version number in setup.py (#176709)`                               |
| [`a153c90e`](https://github.com/NixOS/nixpkgs/commit/a153c90eec38d1a5694c3a8793f5732608b94e8f) | `babashka: 0.8.2 -> 0.8.156`                                                                         |
| [`28cc406b`](https://github.com/NixOS/nixpkgs/commit/28cc406b127651ed10e9ce9de89e4bb0ad4c6f37) | `esshader: init at unstable-2020-08-09`                                                              |
| [`7434c166`](https://github.com/NixOS/nixpkgs/commit/7434c16611902553df66e5d600ff219fc44aa547) | `nix: patch curl netrc regression`                                                                   |
| [`77b40e5c`](https://github.com/NixOS/nixpkgs/commit/77b40e5ccdd2656008255467ac6bfc89dfdcde13) | `circup: 1.0.4 -> 1.1.0`                                                                             |
| [`9d69ea4b`](https://github.com/NixOS/nixpkgs/commit/9d69ea4b7f4e45029c36d84aa06ef960f0d6cbdc) | `nixos/sourcehut: improve testing`                                                                   |
| [`17c6f625`](https://github.com/NixOS/nixpkgs/commit/17c6f625037d103f491f9bc434bb195fe432e78a) | `nixos/sourcehut: some settings became mandatory upstream`                                           |
| [`010488c2`](https://github.com/NixOS/nixpkgs/commit/010488c27b3b77d69d280f339b3c7f54b898fe4b) | `sourcehut.todosrht: 0.71.2 -> 0.72.2`                                                               |
| [`9bd0b0fd`](https://github.com/NixOS/nixpkgs/commit/9bd0b0fdc65953785644e1db5c473b3b36e47d46) | `sourcehut.pastesrht: 0.13.7 -> 0.13.8`                                                              |
| [`2524e0d7`](https://github.com/NixOS/nixpkgs/commit/2524e0d7f37bee8efb8359080e60a961503cbfa0) | `sourcehut.pagessrht: 0.7.3 -> 0.7.4`                                                                |
| [`c32f043d`](https://github.com/NixOS/nixpkgs/commit/c32f043d67d616534c5426ae343666fbd6ebfbd7) | `sourcehut.metasrht: 0.58.8 -> 0.58.18`                                                              |
| [`fa6e3b65`](https://github.com/NixOS/nixpkgs/commit/fa6e3b6509cc59d2ea89c2a65d50932d9e0b594c) | `sourcehut.mansrht: 0.15.25 -> 0.15.26`                                                              |
| [`8388db5a`](https://github.com/NixOS/nixpkgs/commit/8388db5a9ef8735ec6f966b60ce030889b61c51e) | `sourcehut.listssrht: 0.51.10 -> 0.51.11`                                                            |
| [`de3b09c4`](https://github.com/NixOS/nixpkgs/commit/de3b09c4d08861d9ca78756cf08b9df0a2c0c1e3) | `sourcehut.hgsrht: 0.31.2 -> 0.31.3`                                                                 |
| [`0d286b8d`](https://github.com/NixOS/nixpkgs/commit/0d286b8d9671fbb8225ac7e6f548e9b2102c5460) | `sourcehut.gitsrht: 0.78.18 -> 0.78.20`                                                              |
| [`a623fb79`](https://github.com/NixOS/nixpkgs/commit/a623fb79c0cebd0876bdf5fd48eea972846e1965) | `sourcehut.buildsrht: 0.80.0 -> 0.81.0`                                                              |