### PR TITLE
chore(flake/nvim-cmp-src): `033a817c` -> `15c7bf7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -596,11 +596,11 @@
     "nvim-cmp-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1653442331,
-        "narHash": "sha256-DztQOlhSq1kSEl27ygmUo7ctZGrVDq1fBOzGwSKTjXs=",
+        "lastModified": 1654760519,
+        "narHash": "sha256-3wwCf2JCkE8VmXFWvoGXNdxBC6uYiyU7L7eElBnqzDo=",
         "owner": "hrsh7th",
         "repo": "nvim-cmp",
-        "rev": "033a817ced907c8bcdcbe3355d7ea67446264f4b",
+        "rev": "15c7bf7c0dfb7c75eb526c53f9574633c13dc22d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                            | Commit Message                 |
| ------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`15c7bf7c`](https://github.com/hrsh7th/nvim-cmp/commit/15c7bf7c0dfb7c75eb526c53f9574633c13dc22d) | `Update documentation (#1019)` |
| [`ce643c12`](https://github.com/hrsh7th/nvim-cmp/commit/ce643c12f1874207323fa59d50f819748c5bf4cc) | `Fix doc typo (#1025)`         |