### PR TITLE
chore(flake/neogit-src): `441c23d3` -> `0ce803d2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -428,11 +428,11 @@
     "neogit-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654074229,
-        "narHash": "sha256-QXZXoRGvbFNMNUi032qdSkfpUuBgQ9AhfndXObpIXnk=",
+        "lastModified": 1654809082,
+        "narHash": "sha256-yM4kQK69G0EyiGX4kvXTtAh22OTlZqwyUNaQbmYqA2I=",
         "owner": "TimUntersberger",
         "repo": "neogit",
-        "rev": "441c23d355b77f4067a1ad018c5dba64efd7ff7f",
+        "rev": "0ce803d22e361080ec0daf6bee7aad45e8cf8b07",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                  | Commit Message                                                        |
| ------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`f16d35be`](https://github.com/TimUntersberger/neogit/commit/f16d35bef03fb3463f9f02425ed7132262867407) | `(gotofile): don't write the current file at all unless 'hidden' ...` |
| [`920d7e78`](https://github.com/TimUntersberger/neogit/commit/920d7e78c653e5883930e46075b89056c47f49ff) | `fix(status): Adjustments to 'Close' and 'GoToFile'.`                 |
| [`fb08fc24`](https://github.com/TimUntersberger/neogit/commit/fb08fc2491a85881b0ff4504331b7bfc5df9a524) | ``fix(cli): Use `--no-optional-locks`.``                              |