### PR TITLE
chore(flake/kanagawa-nvim-src): `a6db7796` -> `76df2251`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -323,11 +323,11 @@
     "kanagawa-nvim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1652960060,
-        "narHash": "sha256-t9WFzKd6hkmtnti6WNFPFykrI+kxIMXrK8moWIUyWKs=",
+        "lastModified": 1654946852,
+        "narHash": "sha256-WjSUc6g/IC5sGFupIs55rGMz3U99IjfrlaHUR4iz2TI=",
         "owner": "rebelot",
         "repo": "kanagawa.nvim",
-        "rev": "a6db77965a27ca893ea693d69cc3c152c000a627",
+        "rev": "76df2251e813fdec244b2b593be62accea930119",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                 | Commit Message                                             |
| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
| [`e5d940f6`](https://github.com/rebelot/kanagawa.nvim/commit/e5d940f68872b829489b88fcd201694703c75d79) | `fix(hlgroups): use vim.tbl_extend to apply config styles` |
| [`6a30cab7`](https://github.com/rebelot/kanagawa.nvim/commit/6a30cab7b7c0184f06565e102420fc2b8ddaebdc) | `docs(readme): update documentation for overrides`         |
| [`dc51a238`](https://github.com/rebelot/kanagawa.nvim/commit/dc51a2385068083f324b28649cb41c5a7290dfa2) | `refactor!: use nvim_set_hl`                               |