### PR TITLE
chore(flake/nixpkgs): `3f909fb5` -> `72b1ec0a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -464,11 +464,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654875595,
-        "narHash": "sha256-Vairke3ryPSFpgQdaYicPPhPWMGhtzm6V+1uF2Tefbk=",
+        "lastModified": 1655034456,
+        "narHash": "sha256-HXXyvGqZLa+2u8IPIRm/uNQiw+gBtTNu58YaXMJtKRc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3f909fb574d9b9d7294e544981c62a4a5e4599fc",
+        "rev": "72b1ec0a79b1fc50f6cc0694c2f0b1eb384a932e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`e8c87f09`](https://github.com/NixOS/nixpkgs/commit/e8c87f09460c565322f9ef05b781b31c4adcbdfd) | `Revert "metrics job: schedule on any machine, for now"`                 |
| [`961d7293`](https://github.com/NixOS/nixpkgs/commit/961d7293b9cfe1971808db00b54d5e41558d11bc) | `lsd: 0.21.0 -> 0.22.0`                                                  |
| [`31d25569`](https://github.com/NixOS/nixpkgs/commit/31d2556995c61190151e8bedffac5538efc42361) | `lefthook: 0.7.7 -> 0.8.0`                                               |
| [`98fad557`](https://github.com/NixOS/nixpkgs/commit/98fad5577ceafb12c647cfe00adfd2625fc2515f) | `python310Packages.aioskybell: 22.6.0 -> 22.6.1`                         |
| [`4cb7a914`](https://github.com/NixOS/nixpkgs/commit/4cb7a914b11b4db61181d1f9d5efb8cdf1c942c5) | `python310Packages.peaqevcore: 0.4.2 -> 0.4.7`                           |
| [`18bd58aa`](https://github.com/NixOS/nixpkgs/commit/18bd58aa85947bdef47ae3a601fff2d81de0b2d3) | `python310Packages.pyhiveapi: 0.5.9 -> 0.5.10`                           |
| [`7240fe89`](https://github.com/NixOS/nixpkgs/commit/7240fe89a449e9f8f3c4c7bce858875f36bcfc85) | `python310Packages.mkdocs-material: 8.3.3 -> 8.3.4`                      |
| [`f98de352`](https://github.com/NixOS/nixpkgs/commit/f98de352cb25c4ddb5849f954715e571c3034bea) | `python310Packages.pyvesync: 2.0.3 -> 2.0.4`                             |
| [`a8d6ba58`](https://github.com/NixOS/nixpkgs/commit/a8d6ba5802823311e0f87b831410e5d8054aa5bf) | `clojure: 1.11.1.1119 -> 1.11.1.1124`                                    |
| [`ee4e2ac1`](https://github.com/NixOS/nixpkgs/commit/ee4e2ac16962cbb7a3bbe58d8965660a69fc25fc) | `yarn: 1.22.18 -> 1.22.19`                                               |
| [`f42a6bcb`](https://github.com/NixOS/nixpkgs/commit/f42a6bcbf625637f5bca5df5c499323ca8b53969) | `gox: use buildGoModule`                                                 |
| [`d160efc7`](https://github.com/NixOS/nixpkgs/commit/d160efc709563ed24d43e6103c56c3858f6c8cc6) | `terraform-providers: convert remaining hashes to sri`                   |
| [`7550c000`](https://github.com/NixOS/nixpkgs/commit/7550c0002f4d9b6015ed9f30f1a3c4c001cc3491) | `terraform-providers: update 2022-06-11`                                 |
| [`c9f4a4cc`](https://github.com/NixOS/nixpkgs/commit/c9f4a4ccb80be93853e05bff96436498f1f41e80) | `python310Packages.cyclonedx-python-lib: 2.4.0 -> 2.5.1`                 |
| [`07da5279`](https://github.com/NixOS/nixpkgs/commit/07da52796aa8428b24677fcbfb423868018d5691) | `terraform-providers.opennebula: 0.4.3 -> 0.5.0`                         |
| [`46f92ca4`](https://github.com/NixOS/nixpkgs/commit/46f92ca4da555844ce6bc47278d9ed30c7954a4f) | `xfce.exo: 4.16.3 -> 4.16.4`                                             |
| [`c65e990e`](https://github.com/NixOS/nixpkgs/commit/c65e990ed2e50378a26cf10399fe9265fd625fa9) | `openxr-loader: enable wayland`                                          |
| [`54c95acb`](https://github.com/NixOS/nixpkgs/commit/54c95acb8a75c8b40d4af8261d5d99129162ec7c) | `openxr-loader: build tests for hello_xr`                                |
| [`8ed58587`](https://github.com/NixOS/nixpkgs/commit/8ed585876343b451ac5a730e5b56379eefff0dfd) | `proxysql: fix build by using vendored jemalloc 5.2.0`                   |
| [`e9218500`](https://github.com/NixOS/nixpkgs/commit/e9218500bad5fdedbd27e4a6821f81b57a9afc86) | `jemalloc: 5.2.1 -> 5.3.0`                                               |
| [`9b2a771b`](https://github.com/NixOS/nixpkgs/commit/9b2a771b8fe6aef77cd0c713ca2736219cea3472) | `monado: use absolute runtime path in manifest`                          |
| [`3b7fe79b`](https://github.com/NixOS/nixpkgs/commit/3b7fe79bce5c49a2c40789402e9c674cd51dbdc4) | `monado: enable wayland support`                                         |
| [`69c4953f`](https://github.com/NixOS/nixpkgs/commit/69c4953f4b6bf2ed6df453a20be9537d52ceee29) | `ungoogled-chromium: 102.0.5005.61 -> 102.0.5005.115`                    |
| [`90986a50`](https://github.com/NixOS/nixpkgs/commit/90986a500bd63124fbdd3c827f180f19d1aa0b3c) | `maintainers: add kfears`                                                |
| [`49834aef`](https://github.com/NixOS/nixpkgs/commit/49834aef6c3cbf58dea93e77201eb3d088738bda) | `nixos/openvpn3: add enable option`                                      |
| [`445f0e64`](https://github.com/NixOS/nixpkgs/commit/445f0e645e3d9ef72df29a49bb46b3f8d303eb55) | `openvpn3: init at 17_beta`                                              |
| [`a57409b1`](https://github.com/NixOS/nixpkgs/commit/a57409b1159b0a6f6b61b799db593889f83e0931) | `tfsec: 1.21.2 -> 1.23.3`                                                |
| [`c5d8a91b`](https://github.com/NixOS/nixpkgs/commit/c5d8a91b00e2011a248c70a97b50d8b6cc580840) | `faraday-cli: 2.0.2 -> 2.1.5`                                            |
| [`2ea99624`](https://github.com/NixOS/nixpkgs/commit/2ea99624587e6a64ffe9d6ada5414b10d98d7739) | `python310Packages.py-sneakers: init at 1.0.1`                           |
| [`501ec23c`](https://github.com/NixOS/nixpkgs/commit/501ec23c492b1453da2d37f113a132b86f79a0c8) | `distrobox: 1.3.0 -> 1.3.1`                                              |
| [`27d4500b`](https://github.com/NixOS/nixpkgs/commit/27d4500b618468790febcdf7991f69bad94687e9) | `gforth: unmark broken on darwin`                                        |
| [`b71cff07`](https://github.com/NixOS/nixpkgs/commit/b71cff07a73fc7949c22d045bb74c7ef1e9bbb2d) | `gforth: explicitly set lispdir`                                         |
| [`76f2f569`](https://github.com/NixOS/nixpkgs/commit/76f2f569ef7bc092cc6a11ade767587d92d53ad5) | `python310Packages.pulumi-aws: 5.7.2 -> 5.8.0`                           |
| [`af4b5ffa`](https://github.com/NixOS/nixpkgs/commit/af4b5ffa73c5d9e4484a40a897d260e9945f0ce3) | `vector: 0.22.0 -> 0.22.1`                                               |
| [`5b898eb8`](https://github.com/NixOS/nixpkgs/commit/5b898eb8deadc8ba46342c715615af60e62a1e2b) | `sunpaper: init at unstable-2022-04-01`                                  |
| [`2a8762a9`](https://github.com/NixOS/nixpkgs/commit/2a8762a9e5f4a1d8ab7b67175941a33e2b72fd8f) | `werf: 1.2.107 -> 1.2.114`                                               |
| [`cd07d6c8`](https://github.com/NixOS/nixpkgs/commit/cd07d6c82e9d543bff0759a779df393f2687a98c) | `clang-tools: provide many versions`                                     |
| [`24776325`](https://github.com/NixOS/nixpkgs/commit/247763256c6ed9a637b0fa665f83e673dc8dba38) | `clang-tools: don't hardcode list of tools`                              |
| [`e0dc568e`](https://github.com/NixOS/nixpkgs/commit/e0dc568e25cf5c937caa082f6ea1ed82c20efb88) | `mutt: 2.2.4 -> 2.2.5`                                                   |
| [`0f9a77f5`](https://github.com/NixOS/nixpkgs/commit/0f9a77f5cbcfcd59144f33ace06f1670bfc259e9) | `smpeg: fix handling of pkg-config`                                      |
| [`75577189`](https://github.com/NixOS/nixpkgs/commit/7557718913d91c3181f262ba4a366af274f74d41) | `linux-firmware: 20220509 -> 20220610`                                   |
| [`bb390ea9`](https://github.com/NixOS/nixpkgs/commit/bb390ea97f34d6d711145647185e20de91be1bce) | `python310Packages.dogpile-cache: 1.1.5 -> 1.1.6`                        |
| [`87dd8422`](https://github.com/NixOS/nixpkgs/commit/87dd8422384c2c7d2fcba62fd91e55c309a33779) | `bdf2psf: 1.207 -> 1.208`                                                |
| [`e329b995`](https://github.com/NixOS/nixpkgs/commit/e329b995f260ac8e134dfe95565a7dc312afa0db) | `hoard: init at 1.0.1`                                                   |
| [`84e4bf5e`](https://github.com/NixOS/nixpkgs/commit/84e4bf5e0b4ab772e4582ad07761fcc603f4bdc1) | `fclones: 0.25.0 -> 0.26.0`                                              |
| [`58037066`](https://github.com/NixOS/nixpkgs/commit/580370666239e426df70ab4996dc5b5512a2c303) | `nixos/tests: fix type mismatch in wait_for_open_port`                   |
| [`99f3479d`](https://github.com/NixOS/nixpkgs/commit/99f3479d6085b26c1fdd521b7767861c9f589bcc) | `python310Packages.pydal: 20220213.2 -> 20220609.1`                      |
| [`feff6ddb`](https://github.com/NixOS/nixpkgs/commit/feff6ddbe7b9139dd7287dfaa379682bf46c8d3f) | `expressvpn: init at 3.25.0.13`                                          |
| [`03a6fedb`](https://github.com/NixOS/nixpkgs/commit/03a6fedb127aba81984a1ca6818e8841d86338d3) | `firejail: 0.9.68 -> 0.9.70`                                             |
| [`f53b2517`](https://github.com/NixOS/nixpkgs/commit/f53b2517bb2b40e0ff1267619292bfa079fc1703) | `gspell: 1.10.0 -> 1.11.1`                                               |
| [`3aa7a719`](https://github.com/NixOS/nixpkgs/commit/3aa7a7192d929e358ecdaadf3313dd70f0cb05ec) | `exploitdb: 2022-06-04 -> 2022-06-11`                                    |
| [`5e8d7cb7`](https://github.com/NixOS/nixpkgs/commit/5e8d7cb7569d4fcfddcf59fed556cf2a3c928f69) | `angband: add SDL2 frontend`                                             |
| [`3bdfa1e5`](https://github.com/NixOS/nixpkgs/commit/3bdfa1e5f0d4f0f582b3cb36009c5365800ad1f9) | `python310Packages.whois: 0.9.15 -> 0.9.16`                              |
| [`d02648d0`](https://github.com/NixOS/nixpkgs/commit/d02648d09f319a14f984a01074bef1e8c238a08c) | `python310Packages.aurorapy: 0.2.7 -> 0.2.6`                             |
| [`ca6798b6`](https://github.com/NixOS/nixpkgs/commit/ca6798b66b1531f3eea2ca2c3200b75f9e3e60ac) | `dbeaver: 22.0.5 -> 22.1.0`                                              |
| [`1b8803fa`](https://github.com/NixOS/nixpkgs/commit/1b8803fa19d950875e8fcfeffb114261e36a2fdb) | `python310Packages.awscrt: 0.13.11 -> 0.13.13`                           |
| [`26526f02`](https://github.com/NixOS/nixpkgs/commit/26526f02ad016c78fb5bb252d3cd54d4eceb052c) | `nixos/picom: remove deprecated refreshRate option`                      |
| [`5a476dcf`](https://github.com/NixOS/nixpkgs/commit/5a476dcfda2796851ff0e866e7c996b3adf393dc) | `python310Packages.tubeup: 0.0.30 -> 0.0.31`                             |
| [`7c260992`](https://github.com/NixOS/nixpkgs/commit/7c2609922a09041b4965e6c176e892c1d18d83a2) | `python310Packages.transformers: 4.19.3 -> 4.19.4`                       |
| [`02224725`](https://github.com/NixOS/nixpkgs/commit/022247259a88c5c9933174479a21341402d4e317) | `python310Packages.peaqevcore: 0.3.14 -> 0.4.2`                          |
| [`2f6b3d48`](https://github.com/NixOS/nixpkgs/commit/2f6b3d48d1d7662ff97fb14f1258cd5ecd41a0aa) | `ugrep: 3.7.9 -> 3.8.2`                                                  |
| [`3cd8c2f4`](https://github.com/NixOS/nixpkgs/commit/3cd8c2f4577f86abc95501d96739ec0df7190ae6) | `firefox-devedition-bin-unwrapped: 102.0b5 -> 102.0b6`                   |
| [`ec497a13`](https://github.com/NixOS/nixpkgs/commit/ec497a13e313e65ee10083feab2ebcdbc7353c26) | `hound: 0.4.0 -> 0.5.0`                                                  |
| [`2f7a870a`](https://github.com/NixOS/nixpkgs/commit/2f7a870a4c6e364937cfbb2e1ae78a5d15bf1ae9) | `signal-desktop: 5.45.0 -> 5.45.1`                                       |
| [`fdbfdc44`](https://github.com/NixOS/nixpkgs/commit/fdbfdc443cf902b5e8f0e4a3ec7c0aa1c5063026) | `postgresqlPackages.pg_hint_plan: init at 14-1.4.0`                      |
| [`a58c728d`](https://github.com/NixOS/nixpkgs/commit/a58c728d5f9f01c283eb2e25dd54c049dab7533c) | `fwupd: 1.8.0 -> 1.8.1`                                                  |
| [`1f0cd892`](https://github.com/NixOS/nixpkgs/commit/1f0cd892b1dba80f27d260c6b3489a894135cf78) | `home-assistant: 2022.6.4 -> 2022.6.5`                                   |
| [`25966837`](https://github.com/NixOS/nixpkgs/commit/25966837e814d8234443a01815dbd6e8a94fe014) | `python3Packages.pyunifiprotect: 3.8.0 -> 3.9.2`                         |
| [`c0a672b3`](https://github.com/NixOS/nixpkgs/commit/c0a672b343939549b9dc63118d0b839631218819) | `docker: 20.10.16 -> 20.10.17`                                           |
| [`e286e80e`](https://github.com/NixOS/nixpkgs/commit/e286e80e52742ae2a621240b83e4c59008b145bb) | `fuse-overlayfs: 1.8.2 -> 1.9`                                           |
| [`2d997b63`](https://github.com/NixOS/nixpkgs/commit/2d997b63ae5c54019018c5f3704ba52a100cc77e) | `firefox-devedition-bin-unwrapped: 102.0b1 -> 102.0b5`                   |
| [`f9efe722`](https://github.com/NixOS/nixpkgs/commit/f9efe7221975ed53e9de9dfc0e8b09ab7a5e8ae9) | `firefox-beta-bin-unwrapped: 102.0b1 -> 102.0b5`                         |
| [`2ce75137`](https://github.com/NixOS/nixpkgs/commit/2ce7513786a6b6e1fc3e4e597e23ce949bf57ca3) | `firefox-bin-unwrapped: 101.0 -> 101.0.1`                                |
| [`4b582932`](https://github.com/NixOS/nixpkgs/commit/4b582932fbcf3a21a5381aacb02271648d856750) | `firefox-unwrapped: 101.0 -> 101.0.1`                                    |
| [`690125bd`](https://github.com/NixOS/nixpkgs/commit/690125bd0aa0abc1e7380d577a6b27d941cb3c01) | `treewide: update git.kernel.org/cgit homepage URLs`                     |
| [`b8190f93`](https://github.com/NixOS/nixpkgs/commit/b8190f93d5a175cdea9037f7342a9d4bc3f5d137) | `chromiumDev: 104.0.5098.0 -> 104.0.5110.0`                              |
| [`a4471b3a`](https://github.com/NixOS/nixpkgs/commit/a4471b3a974ba52cbee4d0f25a6da391db854a4a) | `chromiumBeta: 103.0.5060.33 -> 103.0.5060.42`                           |
| [`41c362c9`](https://github.com/NixOS/nixpkgs/commit/41c362c9d16c623b5b4b936832a96a34b61595be) | `chromium: 102.0.5005.61 -> 102.0.5005.115`                              |
| [`39215582`](https://github.com/NixOS/nixpkgs/commit/39215582e1eb8e3c3306b19056d7f1f0436efad2) | `pebble: use buildGoModule`                                              |
| [`1851e682`](https://github.com/NixOS/nixpkgs/commit/1851e682ce84b52b4a8cc5cbe1123573ffeecfa7) | `Remove kvark from the maintainers list`                                 |
| [`d154aea9`](https://github.com/NixOS/nixpkgs/commit/d154aea93a5b283dae07751dc928789bac6f7a3c) | `Remove kvark from maintaining Mozilla packages`                         |
| [`d868f89f`](https://github.com/NixOS/nixpkgs/commit/d868f89f0d005a1205279064a9464bf2e63b5303) | `python310Packages.msgpack-numpy: 0.4.7.1 -> 0.4.8`                      |
| [`e0dbdded`](https://github.com/NixOS/nixpkgs/commit/e0dbdded6e63b66fdd0eb22268fda29e52e2ba7a) | `python310Packages.azure-mgmt-compute: disable on older Python releases` |
| [`6bd02ded`](https://github.com/NixOS/nixpkgs/commit/6bd02ded1626c6f56091c78283fed7c0cb90b71c) | `python310Packages.azure-mgmt-compute: 27.0.0 -> 27.1.0`                 |
| [`b4d6c7a4`](https://github.com/NixOS/nixpkgs/commit/b4d6c7a42e8115d76640b5b49263caee1b93dcb1) | `insomnia: 2022.1.1 -> 2022.3.0, fix build`                              |
| [`6f3caa12`](https://github.com/NixOS/nixpkgs/commit/6f3caa12bbea31a5c23b650f8567a5fae4d244f6) | `fsrx: init at 1.0.0 (#177065)`                                          |
| [`29474261`](https://github.com/NixOS/nixpkgs/commit/294742618e5348c54b6eb2cbc77fa783699835de) | `tinystatus: init at unstable-2021-07-09`                                |
| [`dc2f09c8`](https://github.com/NixOS/nixpkgs/commit/dc2f09c87914281c7b7f0456c3724ea53b1f2a68) | `python3Packages.snapcast: add missing packaging dependency`             |
| [`4b872b35`](https://github.com/NixOS/nixpkgs/commit/4b872b35984169477c5be03f43b83d555043c266) | `python310Packages.timetagger: 22.4.2 -> 22.6.2`                         |
| [`c4182b80`](https://github.com/NixOS/nixpkgs/commit/c4182b8047a24630c9ef7dddf09bfb40ec2149cd) | `buildNimPackage: use depsBuildBuild for nim_builder`                    |
| [`676d99ff`](https://github.com/NixOS/nixpkgs/commit/676d99ff218fddf594731942f370b23d9a84b08e) | `nixVersions.unstable: pre20220530 -> pre20220610`                       |
| [`071ac270`](https://github.com/NixOS/nixpkgs/commit/071ac2706d63a151a40220baaf17202da7eacda9) | `gopass: 1.14.2 -> 1.14.3`                                               |
| [`612a0224`](https://github.com/NixOS/nixpkgs/commit/612a022454769efbd1452f726a7977fc958ad1f3) | `goaccess: 1.5.7 -> 1.6`                                                 |
| [`590f97d2`](https://github.com/NixOS/nixpkgs/commit/590f97d2313bb496e53779565fba0d721c7148e5) | `libvirt: 8.1.0 -> 8.4.0`                                                |
| [`f381ffee`](https://github.com/NixOS/nixpkgs/commit/f381ffeed4870eb1130c9c7a5697933b25ceb6fc) | `wslu: 3.2.3 -> 3.2.4`                                                   |
| [`07f1979a`](https://github.com/NixOS/nixpkgs/commit/07f1979a11f436adc67ce126c42e253dd45b520f) | `python310Packages.azure-mgmt-containerservice: 19.1.0 -> 20.0.0`        |
| [`85e4c47d`](https://github.com/NixOS/nixpkgs/commit/85e4c47d2f0ad91625a33f5aad70c6461646056e) | `assh: 2.12.2 -> 2.14.0`                                                 |
| [`8333e7da`](https://github.com/NixOS/nixpkgs/commit/8333e7da369f1cda1aec472ec992044524d549ff) | `metasploit: 6.2.1 -> 6.2.2`                                             |
| [`45d5aef1`](https://github.com/NixOS/nixpkgs/commit/45d5aef19275288f13748183142f865e5035cef1) | `python310Packages.oauthenticator: 15.0.0 -> 15.0.1`                     |
| [`6c425b17`](https://github.com/NixOS/nixpkgs/commit/6c425b1778c2af676e8c632ed90dfbad069bf477) | `datalad: init at 0.16.5`                                                |
| [`8fb0a9c3`](https://github.com/NixOS/nixpkgs/commit/8fb0a9c3db6bec0b1771c5d5a84098c1ed8774f6) | `lndhub-go: 0.7.0 -> 0.8.0`                                              |
| [`2cdf082b`](https://github.com/NixOS/nixpkgs/commit/2cdf082b90b61e0cb9055a2bf1c99301535d3962) | `python310Packages.unicrypto: 0.0.5 -> 0.0.7`                            |
| [`70b75018`](https://github.com/NixOS/nixpkgs/commit/70b75018609ef468c4c334835ab8bde231565b10) | `fluent-bit: add -fcommon workaround`                                    |
| [`44f2769f`](https://github.com/NixOS/nixpkgs/commit/44f2769f055b00606fbb6e14ce2f8a5dc3134f8d) | `ncspot: 0.9.8 -> 0.10.0`                                                |
| [`a7e4a928`](https://github.com/NixOS/nixpkgs/commit/a7e4a928522c6a7de67627906fc7fc7d77ab96ed) | `python39Packages.eve: disable on python 2`                              |
| [`8daa103d`](https://github.com/NixOS/nixpkgs/commit/8daa103d1fecf9d95ecb89a837034cdc18daefe2) | `qdigidoc: Explain why LD_LIBRARY_PATH is required`                      |
| [`ea62d92f`](https://github.com/NixOS/nixpkgs/commit/ea62d92f6368e2da5ca695445b271ec7cb1522ef) | `libdigidocpp: Replace wrap with rpath addition`                         |
| [`eb900ded`](https://github.com/NixOS/nixpkgs/commit/eb900ded42e95632bcc06f3b19238c9222c2ba8c) | `refind: Fix possible NULL dereference`                                  |
| [`90f443a1`](https://github.com/NixOS/nixpkgs/commit/90f443a17b6c2b7eab033eef1fc558c1c23a2e77) | `speed-dreams: 2.2.2 -> 2.2.3`                                           |
| [`e86e7ee1`](https://github.com/NixOS/nixpkgs/commit/e86e7ee1a8931b98c6f3fa5c8f09ca57864998a0) | `libvirt: add passthru update script`                                    |
| [`c8b8ea82`](https://github.com/NixOS/nixpkgs/commit/c8b8ea8232f9b0f454d2614a9200858e38c7ef25) | `libvirt: drop tarball fetching`                                         |
| [`3df045e6`](https://github.com/NixOS/nixpkgs/commit/3df045e6d5ea17ffaaf9d1ec0c82b8eb1bae0faf) | `nixos/systemd: use cfg.package in systemPackages to avoid confusion`    |
| [`acf23020`](https://github.com/NixOS/nixpkgs/commit/acf23020f04182974d820526801a54912e619603) | `snakemake: 7.8.1 -> 7.8.2`                                              |
| [`06aa6468`](https://github.com/NixOS/nixpkgs/commit/06aa64684c6746eb54aea86f981d82b60f544657) | `nixos/doc: document how to use kexecTree`                               |
| [`cdaaf95e`](https://github.com/NixOS/nixpkgs/commit/cdaaf95e206c295404b189882db2f7d294d2cbe8) | ``nixos/release.nix: expose a `kexec.$system` attribute``                |
| [`50648f56`](https://github.com/NixOS/nixpkgs/commit/50648f568d2c988dc53d4ea82da622eca0fe3dd7) | `nixos/…/kexec-boot.nix: move into netboot.nix, rename to kexecTree`     |
| [`567b298a`](https://github.com/NixOS/nixpkgs/commit/567b298ada99fd1af2fd481126bcefe45f7eb249) | `python310Packages.fastavro: 1.4.12 -> 1.5.1`                            |
| [`bc298a03`](https://github.com/NixOS/nixpkgs/commit/bc298a038f5469099ff5b4a8da40f368aa620111) | `python310Packages.sagemaker: 2.93.1 -> 2.94.0`                          |
| [`2340d0c1`](https://github.com/NixOS/nixpkgs/commit/2340d0c184c60134eb6c85582c47d9c7ce44cf41) | `nodePackages.prisma: 3.14.0 -> 3.15.1`                                  |
| [`ecf2837a`](https://github.com/NixOS/nixpkgs/commit/ecf2837a2922e33497cc3c156a71dec007839bcc) | `prisma-engines: 3.14.0 -> 3.15.1`                                       |
| [`13dce8e6`](https://github.com/NixOS/nixpkgs/commit/13dce8e6b757f1eadf0e7d4edf997426c462a6e0) | `nats-server: 2.7.4 -> 2.8.4`                                            |
| [`871ea2c4`](https://github.com/NixOS/nixpkgs/commit/871ea2c4352d0248b04925dd6cdd550e27c95a7f) | `updated color patch`                                                    |
| [`d4ff221c`](https://github.com/NixOS/nixpkgs/commit/d4ff221c45dc656ea65ae4c9cc8fa58e64694dfe) | `updated color patch`                                                    |
| [`f50d327f`](https://github.com/NixOS/nixpkgs/commit/f50d327f00f00147c4fb9abb083baf311273d3ac) | `updated color patch`                                                    |
| [`30136854`](https://github.com/NixOS/nixpkgs/commit/30136854150b1f795883d3f17a85f844288f575f) | `python310Packages.azure-mgmt-cognitiveservices: 13.1.0 -> 13.2.0`       |