### PR TITLE
chore(flake/nixpkgs-master): `5bc0350e` -> `37b6b161`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1654970968,
-        "narHash": "sha256-Ufo/ta2UbojY9VScQ5W6eCrQh32ilRL0WbWfXeGHTMY=",
+        "lastModified": 1655087213,
+        "narHash": "sha256-4R5oQ+OwGAAcXWYrxC4gFMTUSstGxaN8kN7e8hkum/8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5bc0350e7cfe42218bf914ecec80c9a846642ca5",
+        "rev": "37b6b161e536fddca54424cf80662bce735bdd1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
| [`beb707c4`](https://github.com/NixOS/nixpkgs/commit/beb707c4e6f454c084ae733a374f1efde5f4ad73) | `python3Packages.vqgan-jax: init at unstable-2022-04-20`                                                               |
| [`7527d536`](https://github.com/NixOS/nixpkgs/commit/7527d53617486517f4a6ce8f252ef549139c9633) | `python3Packages.dalle-mini: init at 0.1.0`                                                                            |
| [`e3dc5bf1`](https://github.com/NixOS/nixpkgs/commit/e3dc5bf1307611af889de1c9c98658f97e03a59a) | `authenticator: 4.1.2 -> 4.1.4`                                                                                        |
| [`9e8e5c78`](https://github.com/NixOS/nixpkgs/commit/9e8e5c785e23e71b34641b54b0141d92509cce69) | `python310Packages.rmcl: init at 0.4.2`                                                                                |
| [`77087c71`](https://github.com/NixOS/nixpkgs/commit/77087c710f7938649cbc240e79a593c52fb8b342) | `python310Packages.asks: init at 3.0.0`                                                                                |
| [`0a24fb2a`](https://github.com/NixOS/nixpkgs/commit/0a24fb2a96e791023287380ad92c8384ea9a7117) | `python310Packages.overly: init at 0.1.85`                                                                             |
| [`2aa3a9bb`](https://github.com/NixOS/nixpkgs/commit/2aa3a9bba018e8402677b528a6b787dd8dd791a2) | `python310Packages.sansio-multipart: init at 0.3`                                                                      |
| [`03daf984`](https://github.com/NixOS/nixpkgs/commit/03daf984411d1747c42722804cf20e3773bb56ce) | `python310Packages.rmrl: init at 0.2.1`                                                                                |
| [`0bb1beda`](https://github.com/NixOS/nixpkgs/commit/0bb1bedab16c0d5e6fbe0fec3b5fa7dc81296baa) | `python310Packages.svglib: use pytestCheckHook`                                                                        |
| [`e5860e40`](https://github.com/NixOS/nixpkgs/commit/e5860e40fd660232e5a1d2512d3f278bf366d795) | `python310Packages.greeclimate: 1.2.0 -> 1.2.1`                                                                        |
| [`dd1000d6`](https://github.com/NixOS/nixpkgs/commit/dd1000d608266b99f38460aca9f12b856ae0a4c7) | `python310Packages.nextcord: 2.0.0b2 -> 2.0.0b3`                                                                       |
| [`24375ea5`](https://github.com/NixOS/nixpkgs/commit/24375ea5727c44891ca437710aed0d565c48aa7b) | `python310Packages.pytest-annotate: 1.0.4 -> 1.0.5`                                                                    |
| [`2ecca8bd`](https://github.com/NixOS/nixpkgs/commit/2ecca8bd9e601ccef0b6d4c67e207d678f50835f) | `ooniprobe-cli: 3.15.0 -> 3.15.1`                                                                                      |
| [`dfe98e2c`](https://github.com/NixOS/nixpkgs/commit/dfe98e2c07079bd9aa320032613b4df5de6dc321) | `catch2: 2.13.8 -> 2.13.9`                                                                                             |
| [`fd0605d0`](https://github.com/NixOS/nixpkgs/commit/fd0605d0d2474fe7c7c8df7a469a988ef79c76cd) | `abcmidi: 2022.05.20 -> 2022.06.07`                                                                                    |
| [`cc73dc83`](https://github.com/NixOS/nixpkgs/commit/cc73dc83b36b76baab8bf2282c2e0fcc1ebbbd5a) | `Revert "nixos/security/wrappers: use an assertion for the existence check"`                                           |
| [`4ae57843`](https://github.com/NixOS/nixpkgs/commit/4ae57843bac2e041923ff8c308d722fb923e6906) | `ventoy-bin: 1.0.75 -> 1.0.76`                                                                                         |
| [`efc04d51`](https://github.com/NixOS/nixpkgs/commit/efc04d51febd184b3a743c87e53994aab383db06) | `python310Packages.xmlschema: 1.11.1 -> 1.11.2`                                                                        |
| [`b25f38ac`](https://github.com/NixOS/nixpkgs/commit/b25f38ac4e210f88aaf394471e11b002b79b11e2) | `krita: 5.0.6 -> 5.0.8`                                                                                                |
| [`c602569c`](https://github.com/NixOS/nixpkgs/commit/c602569c9de4d51bb1cd9d5f0c88c914cd183ae5) | `maintainers: add nek0`                                                                                                |
| [`74b3456a`](https://github.com/NixOS/nixpkgs/commit/74b3456a75de1510abf714dfa5097bcd65ca7ddc) | `vopono: 0.8.10 -> 0.9.1`                                                                                              |
| [`fd2a89b9`](https://github.com/NixOS/nixpkgs/commit/fd2a89b98330f4a06636ef19f34716d68ea7fe71) | ``nixos/wpa_supplicant: don't log that wpa_supplicant.conf is ignored with `allowAuxiliaryImperativeNetworks = true``` |
| [`24a46503`](https://github.com/NixOS/nixpkgs/commit/24a46503dfe430dd3ad9fad1ac88da1de21436da) | `bluewalker: 0.3.0 -> 0.3.1`                                                                                           |
| [`09905953`](https://github.com/NixOS/nixpkgs/commit/099059530967f724cad3227716e53f5b57c393b3) | `rtl8821cu: 2022-03-08 -> 2022-05-07`                                                                                  |
| [`e17c1d5a`](https://github.com/NixOS/nixpkgs/commit/e17c1d5a52f1397bdecc2e0dc8d094aa081cbb1d) | `kodi.packages.urllib3: 1.26.4+matrix.1 -> 1.26.8+matrix.1`                                                            |
| [`f78374bf`](https://github.com/NixOS/nixpkgs/commit/f78374bfa5f0535f80dc5b0c8bf62072661381c4) | `python3Packages.afdko: skip broken test on armv7l (#177400)`                                                          |
| [`d6d847bc`](https://github.com/NixOS/nixpkgs/commit/d6d847bc396c9e0ab52a888d93a5e4fbac52c856) | `okteto: 2.3.1 -> 2.3.3`                                                                                               |
| [`324df04b`](https://github.com/NixOS/nixpkgs/commit/324df04b67cf92017138a13737e7500e67060eb0) | `linuxPackages: use 5_10 kernel on 32-bit platforms`                                                                   |
| [`dd63da94`](https://github.com/NixOS/nixpkgs/commit/dd63da9494c30dc7d13c16f6fe58673746592511) | `hwatch: init at 0.3.6`                                                                                                |
| [`1b9bacef`](https://github.com/NixOS/nixpkgs/commit/1b9baceff43bff11ca97dd1a89e6fc52e83c9058) | `python3Packages.uvloop: disable problematic test on armv7l too`                                                       |
| [`85a49d0a`](https://github.com/NixOS/nixpkgs/commit/85a49d0af879a7aecd7a01ea00a06cde5f38e936) | `python310Packages.plugwise: 0.19.0 -> 0.19.1`                                                                         |
| [`bf580b0e`](https://github.com/NixOS/nixpkgs/commit/bf580b0edebbd6d862749e545a740a33eb358169) | `python310Packages.asf-search: 3.0.6 -> 3.2.2`                                                                         |
| [`218093d3`](https://github.com/NixOS/nixpkgs/commit/218093d36a5846643a5fb8ba5abfcdec6d00de4c) | `python310Packages.wktutils: init at 1.1.4`                                                                            |
| [`67512331`](https://github.com/NixOS/nixpkgs/commit/67512331eb8317dd07982f39486f1f071ac0d3a1) | `python310Packages.kml2geojson: init at 5.1.0`                                                                         |
| [`872695d0`](https://github.com/NixOS/nixpkgs/commit/872695d02b9a8f23d7e0cca0ab6331039ca3c108) | `krita: fix double wrapping`                                                                                           |
| [`e8c87f09`](https://github.com/NixOS/nixpkgs/commit/e8c87f09460c565322f9ef05b781b31c4adcbdfd) | `Revert "metrics job: schedule on any machine, for now"`                                                               |
| [`1785ce8d`](https://github.com/NixOS/nixpkgs/commit/1785ce8db1d7458f11788158263288fb2f94d40e) | `python310Packages.browser-cookie3: 0.14.2 -> 0.14.3`                                                                  |
| [`d5a87ede`](https://github.com/NixOS/nixpkgs/commit/d5a87edeab9fe4c3bdd85f14e230bddf86d88e03) | `buildMozillaMach: allow PGO on all Linux platforms`                                                                   |
| [`65666128`](https://github.com/NixOS/nixpkgs/commit/65666128992f73018e4cad71a7e96813f2031b19) | `sshfs: 3.7.2 -> 3.7.3`                                                                                                |
| [`8ae485e7`](https://github.com/NixOS/nixpkgs/commit/8ae485e75b352cd11bba96bc20d7e65913178054) | `python310Packages.entrypoint2: add format`                                                                            |
| [`961d7293`](https://github.com/NixOS/nixpkgs/commit/961d7293b9cfe1971808db00b54d5e41558d11bc) | `lsd: 0.21.0 -> 0.22.0`                                                                                                |
| [`31d25569`](https://github.com/NixOS/nixpkgs/commit/31d2556995c61190151e8bedffac5538efc42361) | `lefthook: 0.7.7 -> 0.8.0`                                                                                             |
| [`98fad557`](https://github.com/NixOS/nixpkgs/commit/98fad5577ceafb12c647cfe00adfd2625fc2515f) | `python310Packages.aioskybell: 22.6.0 -> 22.6.1`                                                                       |
| [`4cb7a914`](https://github.com/NixOS/nixpkgs/commit/4cb7a914b11b4db61181d1f9d5efb8cdf1c942c5) | `python310Packages.peaqevcore: 0.4.2 -> 0.4.7`                                                                         |
| [`18bd58aa`](https://github.com/NixOS/nixpkgs/commit/18bd58aa85947bdef47ae3a601fff2d81de0b2d3) | `python310Packages.pyhiveapi: 0.5.9 -> 0.5.10`                                                                         |
| [`7240fe89`](https://github.com/NixOS/nixpkgs/commit/7240fe89a449e9f8f3c4c7bce858875f36bcfc85) | `python310Packages.mkdocs-material: 8.3.3 -> 8.3.4`                                                                    |
| [`f98de352`](https://github.com/NixOS/nixpkgs/commit/f98de352cb25c4ddb5849f954715e571c3034bea) | `python310Packages.pyvesync: 2.0.3 -> 2.0.4`                                                                           |
| [`a8d6ba58`](https://github.com/NixOS/nixpkgs/commit/a8d6ba5802823311e0f87b831410e5d8054aa5bf) | `clojure: 1.11.1.1119 -> 1.11.1.1124`                                                                                  |
| [`9d84f435`](https://github.com/NixOS/nixpkgs/commit/9d84f435e351dfe89f5e7b1c7ca6f4cdb3fe06aa) | `nixVersions.nix_2_9: pull patch to add missing git-dir flags`                                                         |
| [`ee4e2ac1`](https://github.com/NixOS/nixpkgs/commit/ee4e2ac16962cbb7a3bbe58d8965660a69fc25fc) | `yarn: 1.22.18 -> 1.22.19`                                                                                             |
| [`f42a6bcb`](https://github.com/NixOS/nixpkgs/commit/f42a6bcbf625637f5bca5df5c499323ca8b53969) | `gox: use buildGoModule`                                                                                               |
| [`d160efc7`](https://github.com/NixOS/nixpkgs/commit/d160efc709563ed24d43e6103c56c3858f6c8cc6) | `terraform-providers: convert remaining hashes to sri`                                                                 |
| [`7550c000`](https://github.com/NixOS/nixpkgs/commit/7550c0002f4d9b6015ed9f30f1a3c4c001cc3491) | `terraform-providers: update 2022-06-11`                                                                               |
| [`c9f4a4cc`](https://github.com/NixOS/nixpkgs/commit/c9f4a4ccb80be93853e05bff96436498f1f41e80) | `python310Packages.cyclonedx-python-lib: 2.4.0 -> 2.5.1`                                                               |
| [`07da5279`](https://github.com/NixOS/nixpkgs/commit/07da52796aa8428b24677fcbfb423868018d5691) | `terraform-providers.opennebula: 0.4.3 -> 0.5.0`                                                                       |
| [`46f92ca4`](https://github.com/NixOS/nixpkgs/commit/46f92ca4da555844ce6bc47278d9ed30c7954a4f) | `xfce.exo: 4.16.3 -> 4.16.4`                                                                                           |
| [`39a56c76`](https://github.com/NixOS/nixpkgs/commit/39a56c7696aee49ef0c6cf4747cc44097db79b84) | `nixos/security/wrappers: use an assertion for the existence check`                                                    |
| [`c65e990e`](https://github.com/NixOS/nixpkgs/commit/c65e990ed2e50378a26cf10399fe9265fd625fa9) | `openxr-loader: enable wayland`                                                                                        |
| [`54c95acb`](https://github.com/NixOS/nixpkgs/commit/54c95acb8a75c8b40d4af8261d5d99129162ec7c) | `openxr-loader: build tests for hello_xr`                                                                              |
| [`8ed58587`](https://github.com/NixOS/nixpkgs/commit/8ed585876343b451ac5a730e5b56379eefff0dfd) | `proxysql: fix build by using vendored jemalloc 5.2.0`                                                                 |
| [`e9218500`](https://github.com/NixOS/nixpkgs/commit/e9218500bad5fdedbd27e4a6821f81b57a9afc86) | `jemalloc: 5.2.1 -> 5.3.0`                                                                                             |
| [`9b2a771b`](https://github.com/NixOS/nixpkgs/commit/9b2a771b8fe6aef77cd0c713ca2736219cea3472) | `monado: use absolute runtime path in manifest`                                                                        |
| [`3b7fe79b`](https://github.com/NixOS/nixpkgs/commit/3b7fe79bce5c49a2c40789402e9c674cd51dbdc4) | `monado: enable wayland support`                                                                                       |
| [`69c4953f`](https://github.com/NixOS/nixpkgs/commit/69c4953f4b6bf2ed6df453a20be9537d52ceee29) | `ungoogled-chromium: 102.0.5005.61 -> 102.0.5005.115`                                                                  |
| [`90986a50`](https://github.com/NixOS/nixpkgs/commit/90986a500bd63124fbdd3c827f180f19d1aa0b3c) | `maintainers: add kfears`                                                                                              |
| [`49834aef`](https://github.com/NixOS/nixpkgs/commit/49834aef6c3cbf58dea93e77201eb3d088738bda) | `nixos/openvpn3: add enable option`                                                                                    |
| [`445f0e64`](https://github.com/NixOS/nixpkgs/commit/445f0e645e3d9ef72df29a49bb46b3f8d303eb55) | `openvpn3: init at 17_beta`                                                                                            |
| [`a57409b1`](https://github.com/NixOS/nixpkgs/commit/a57409b1159b0a6f6b61b799db593889f83e0931) | `tfsec: 1.21.2 -> 1.23.3`                                                                                              |
| [`c5d8a91b`](https://github.com/NixOS/nixpkgs/commit/c5d8a91b00e2011a248c70a97b50d8b6cc580840) | `faraday-cli: 2.0.2 -> 2.1.5`                                                                                          |
| [`2ea99624`](https://github.com/NixOS/nixpkgs/commit/2ea99624587e6a64ffe9d6ada5414b10d98d7739) | `python310Packages.py-sneakers: init at 1.0.1`                                                                         |
| [`501ec23c`](https://github.com/NixOS/nixpkgs/commit/501ec23c492b1453da2d37f113a132b86f79a0c8) | `distrobox: 1.3.0 -> 1.3.1`                                                                                            |
| [`7149c5cb`](https://github.com/NixOS/nixpkgs/commit/7149c5cb604a0a661c27fc2fc8286ddf0efcee46) | `mpd: fix socket activation`                                                                                           |
| [`27d4500b`](https://github.com/NixOS/nixpkgs/commit/27d4500b618468790febcdf7991f69bad94687e9) | `gforth: unmark broken on darwin`                                                                                      |
| [`b71cff07`](https://github.com/NixOS/nixpkgs/commit/b71cff07a73fc7949c22d045bb74c7ef1e9bbb2d) | `gforth: explicitly set lispdir`                                                                                       |
| [`76f2f569`](https://github.com/NixOS/nixpkgs/commit/76f2f569ef7bc092cc6a11ade767587d92d53ad5) | `python310Packages.pulumi-aws: 5.7.2 -> 5.8.0`                                                                         |
| [`2a8762a9`](https://github.com/NixOS/nixpkgs/commit/2a8762a9e5f4a1d8ab7b67175941a33e2b72fd8f) | `werf: 1.2.107 -> 1.2.114`                                                                                             |
| [`e0dc568e`](https://github.com/NixOS/nixpkgs/commit/e0dc568e25cf5c937caa082f6ea1ed82c20efb88) | `mutt: 2.2.4 -> 2.2.5`                                                                                                 |
| [`d574ec79`](https://github.com/NixOS/nixpkgs/commit/d574ec79cb8ed92bda77204f0a3cd6e313ac56e6) | `python310Packages.entrypoint2: 1.0 -> 1.1`                                                                            |
| [`00a84f9f`](https://github.com/NixOS/nixpkgs/commit/00a84f9f2fba3f924888649391078b86c9c61b57) | `palemoon: Fix 31.1.0 bump`                                                                                            |
| [`514bd27e`](https://github.com/NixOS/nixpkgs/commit/514bd27e9210b732ca191695445eb43083e18fe2) | `libreswan: 4.6 -> 4.7`                                                                                                |
| [`bb390ea9`](https://github.com/NixOS/nixpkgs/commit/bb390ea97f34d6d711145647185e20de91be1bce) | `python310Packages.dogpile-cache: 1.1.5 -> 1.1.6`                                                                      |
| [`84e4bf5e`](https://github.com/NixOS/nixpkgs/commit/84e4bf5e0b4ab772e4582ad07761fcc603f4bdc1) | `fclones: 0.25.0 -> 0.26.0`                                                                                            |
| [`58037066`](https://github.com/NixOS/nixpkgs/commit/580370666239e426df70ab4996dc5b5512a2c303) | `nixos/tests: fix type mismatch in wait_for_open_port`                                                                 |
| [`99f3479d`](https://github.com/NixOS/nixpkgs/commit/99f3479d6085b26c1fdd521b7767861c9f589bcc) | `python310Packages.pydal: 20220213.2 -> 20220609.1`                                                                    |
| [`03a6fedb`](https://github.com/NixOS/nixpkgs/commit/03a6fedb127aba81984a1ca6818e8841d86338d3) | `firejail: 0.9.68 -> 0.9.70`                                                                                           |
| [`547ea4a9`](https://github.com/NixOS/nixpkgs/commit/547ea4a972f64bb1cc4922eb0f2069715da631b1) | `maintainers: add hamburger1984`                                                                                       |
| [`5a476dcf`](https://github.com/NixOS/nixpkgs/commit/5a476dcfda2796851ff0e866e7c996b3adf393dc) | `python310Packages.tubeup: 0.0.30 -> 0.0.31`                                                                           |
| [`7c260992`](https://github.com/NixOS/nixpkgs/commit/7c2609922a09041b4965e6c176e892c1d18d83a2) | `python310Packages.transformers: 4.19.3 -> 4.19.4`                                                                     |
| [`2f6b3d48`](https://github.com/NixOS/nixpkgs/commit/2f6b3d48d1d7662ff97fb14f1258cd5ecd41a0aa) | `ugrep: 3.7.9 -> 3.8.2`                                                                                                |
| [`3cd8c2f4`](https://github.com/NixOS/nixpkgs/commit/3cd8c2f4577f86abc95501d96739ec0df7190ae6) | `firefox-devedition-bin-unwrapped: 102.0b5 -> 102.0b6`                                                                 |
| [`94dba70a`](https://github.com/NixOS/nixpkgs/commit/94dba70a05f3b3bc2048b888203ff9fce8fb8ba2) | `vault-bin: 1.10.3 -> 1.10.4`                                                                                          |
| [`54587c3b`](https://github.com/NixOS/nixpkgs/commit/54587c3b1f3d983bc1d9c50776100f394b01c889) | `vault: 1.10.3 -> 1.10.4`                                                                                              |
| [`ec497a13`](https://github.com/NixOS/nixpkgs/commit/ec497a13e313e65ee10083feab2ebcdbc7353c26) | `hound: 0.4.0 -> 0.5.0`                                                                                                |
| [`5dc09cd8`](https://github.com/NixOS/nixpkgs/commit/5dc09cd84f4456c6d3ce3b601a0c91c15dbccc33) | `linux/hardened/patches/5.4: 5.4.196-hardened1 -> 5.4.197-hardened1`                                                   |
| [`a2c6e437`](https://github.com/NixOS/nixpkgs/commit/a2c6e4372a49bd5d6e2e5ddf2e181ad6a258597c) | `linux/hardened/patches/5.18: init at 5.18.3-hardened1`                                                                |
| [`39215582`](https://github.com/NixOS/nixpkgs/commit/39215582e1eb8e3c3306b19056d7f1f0436efad2) | `pebble: use buildGoModule`                                                                                            |
| [`f61e9f4a`](https://github.com/NixOS/nixpkgs/commit/f61e9f4a536c0b0afacd2eace7317f32b33ab778) | `linux/hardened/patches/5.17: 5.17.11-hardened1 -> 5.17.14-hardened1`                                                  |
| [`de36193d`](https://github.com/NixOS/nixpkgs/commit/de36193dee5973147419a5819498f973f2fc6c40) | `linux/hardened/patches/5.15: 5.15.43-hardened1 -> 5.15.46-hardened1`                                                  |
| [`858741e8`](https://github.com/NixOS/nixpkgs/commit/858741e87213845fdb74b87ec50d5fd002ff18ce) | `linux/hardened/patches/5.10: 5.10.118-hardened1 -> 5.10.121-hardened1`                                                |
| [`1c31d966`](https://github.com/NixOS/nixpkgs/commit/1c31d9666e4ad96f06111997870cd43875bf1dc3) | `linux/hardened/patches/4.19: 4.19.245-hardened1 -> 4.19.246-hardened1`                                                |
| [`67a664c5`](https://github.com/NixOS/nixpkgs/commit/67a664c575335508a2f7afc65dbe78151ad1a244) | `linux/hardened/patches/4.14: 4.14.281-hardened1 -> 4.14.282-hardened1`                                                |
| [`87e0009c`](https://github.com/NixOS/nixpkgs/commit/87e0009cd59f73d2f00c481a255b81d80a20e082) | `linux_latest-libre: 18738 -> 18777`                                                                                   |
| [`e457a676`](https://github.com/NixOS/nixpkgs/commit/e457a67642a0460f13b7b64749361d444a0e2d2d) | `linux-rt_5_10: 5.10.115-rt67 -> 5.10.120-rt70`                                                                        |
| [`45a098de`](https://github.com/NixOS/nixpkgs/commit/45a098de80741473ce865f8c091d828a629fd33f) | `linux: 5.4.196 -> 5.4.197`                                                                                            |
| [`260e08a6`](https://github.com/NixOS/nixpkgs/commit/260e08a6e64631a6c04ed6807caf6a96007ee8fb) | `linux: 5.18 -> 5.18.3`                                                                                                |
| [`363c71ff`](https://github.com/NixOS/nixpkgs/commit/363c71ff3cb469f90a4dce78e01eabbe53076d09) | `linux: 5.17.11 -> 5.17.14`                                                                                            |
| [`19d98662`](https://github.com/NixOS/nixpkgs/commit/19d986621529a9cbb8bd9d39a96efea53df99d7d) | `linux: 5.15.43 -> 5.15.46`                                                                                            |
| [`a7757d8a`](https://github.com/NixOS/nixpkgs/commit/a7757d8a946c36a3eab8b340cf3155c71ca1df21) | `linux: 5.10.118 -> 5.10.121`                                                                                          |
| [`2ac8909c`](https://github.com/NixOS/nixpkgs/commit/2ac8909c8b5c7d7e0c19b84e2a8bc703ef5674a2) | `linux: 4.9.316 -> 4.9.317`                                                                                            |
| [`c6c98c48`](https://github.com/NixOS/nixpkgs/commit/c6c98c48b4bb91ad3998b291e79ea1d9110138a0) | `linux: 4.19.245 -> 4.19.246`                                                                                          |
| [`deaf61da`](https://github.com/NixOS/nixpkgs/commit/deaf61dab10a18898bc38065ae760bbfd20240e2) | `linux: 4.14.281 -> 4.14.282`                                                                                          |
| [`8fb0a9c3`](https://github.com/NixOS/nixpkgs/commit/8fb0a9c3db6bec0b1771c5d5a84098c1ed8774f6) | `lndhub-go: 0.7.0 -> 0.8.0`                                                                                            |
| [`70b75018`](https://github.com/NixOS/nixpkgs/commit/70b75018609ef468c4c334835ab8bde231565b10) | `fluent-bit: add -fcommon workaround`                                                                                  |
| [`8daa103d`](https://github.com/NixOS/nixpkgs/commit/8daa103d1fecf9d95ecb89a837034cdc18daefe2) | `qdigidoc: Explain why LD_LIBRARY_PATH is required`                                                                    |
| [`ea62d92f`](https://github.com/NixOS/nixpkgs/commit/ea62d92f6368e2da5ca695445b271ec7cb1522ef) | `libdigidocpp: Replace wrap with rpath addition`                                                                       |
| [`3df045e6`](https://github.com/NixOS/nixpkgs/commit/3df045e6d5ea17ffaaf9d1ec0c82b8eb1bae0faf) | `nixos/systemd: use cfg.package in systemPackages to avoid confusion`                                                  |
| [`06aa6468`](https://github.com/NixOS/nixpkgs/commit/06aa64684c6746eb54aea86f981d82b60f544657) | `nixos/doc: document how to use kexecTree`                                                                             |
| [`cdaaf95e`](https://github.com/NixOS/nixpkgs/commit/cdaaf95e206c295404b189882db2f7d294d2cbe8) | ``nixos/release.nix: expose a `kexec.$system` attribute``                                                              |
| [`50648f56`](https://github.com/NixOS/nixpkgs/commit/50648f568d2c988dc53d4ea82da622eca0fe3dd7) | `nixos/…/kexec-boot.nix: move into netboot.nix, rename to kexecTree`                                                   |
| [`42ceb20d`](https://github.com/NixOS/nixpkgs/commit/42ceb20d291c9a63dcdb28a6b127850030b2b457) | `nixos/gnome: make it possible to remove core packages`                                                                |
| [`ca23e421`](https://github.com/NixOS/nixpkgs/commit/ca23e4210555f1bcb1a6b628bbe1d5e40f1b9d8d) | `nixos/gnome: Move sessionPath to core-shell group`                                                                    |
| [`016b99dc`](https://github.com/NixOS/nixpkgs/commit/016b99dce68d2957cecfbe8ee0a6b328f543cda8) | `nixos/gnome: drop hicolor-icon-theme`                                                                                 |
| [`7f0ce26b`](https://github.com/NixOS/nixpkgs/commit/7f0ce26bbd35606fe656c8d9c829bda0aaddc1ad) | `nixos/xdg/icons: Install hicolor-icon-theme`                                                                          |
| [`aad39fe4`](https://github.com/NixOS/nixpkgs/commit/aad39fe41a3c9d7fb0dd438748c02f29e08fa15b) | `nixos/gnome: drop shared-mime-info`                                                                                   |
| [`b8c87def`](https://github.com/NixOS/nixpkgs/commit/b8c87def6591c4c80263fdf2c79f5cdc845ec7bc) | `hydroxide: 0.2.21 -> 0.2.23`                                                                                          |
| [`5a24bb74`](https://github.com/NixOS/nixpkgs/commit/5a24bb74d6157457e9ba483dc5c1e51924d7a4c6) | `sudo: 1.9.10 -> 1.9.11p1`                                                                                             |
| [`8de1e9e2`](https://github.com/NixOS/nixpkgs/commit/8de1e9e2f88e82df7fcdc109ed58b2db2da59ce7) | `nixos/wg-quick: added support for configuration files`                                                                |
| [`a65fab6b`](https://github.com/NixOS/nixpkgs/commit/a65fab6b629bbc56573c407545aa646db0c28684) | `gtg: 0.5 -> 0.6`                                                                                                      |
| [`050ca6ef`](https://github.com/NixOS/nixpkgs/commit/050ca6ef8faeb3f3519478efafad94b847bd8177) | `dvc: add overrides for scmrepo and grandalf`                                                                          |
| [`093a0036`](https://github.com/NixOS/nixpkgs/commit/093a00363968481243c52cfda6fc66d315674596) | `yarn2nix: allow setting doDist by calling packages`                                                                   |
| [`14bc4210`](https://github.com/NixOS/nixpkgs/commit/14bc4210b706d9f58d6dcc13d81d54f79914bba3) | `element-{web,desktop}: compile from source`                                                                           |
| [`f888642e`](https://github.com/NixOS/nixpkgs/commit/f888642ec69962a5da2e80c69b731d89e61f637d) | `Remove nixUnstable`                                                                                                   |
| [`d61ce444`](https://github.com/NixOS/nixpkgs/commit/d61ce4445c351a8084c0c5411e4acf5a3fbb6daf) | `aegisub: 3.2.2 -> 3.3.2`                                                                                              |
| [`f280a5db`](https://github.com/NixOS/nixpkgs/commit/f280a5db2b56daeea61e689e48259ca6ca66a365) | `pgweb: 0.11.7 -> 0.11.11`                                                                                             |
| [`e14aabb3`](https://github.com/NixOS/nixpkgs/commit/e14aabb3f6e12077fa3450b5fb6f1260e70e1e9c) | `awsls: init at 0.11.0`                                                                                                |