### PR TITLE
chore(flake/telescope-nvim-src): `e6b69b14` -> `e2a77a54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -876,11 +876,11 @@
     "telescope-nvim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654502820,
-        "narHash": "sha256-R8xjY1mF0L33vYA1zeWFzlJE2C3P7tjcBnZpuGgiARg=",
+        "lastModified": 1655031792,
+        "narHash": "sha256-6wWTu0Fu1HhqXwmGJARyswjpf+PV0Yc9fGJRKS8ksdo=",
         "owner": "nvim-telescope",
         "repo": "telescope.nvim",
-        "rev": "e6b69b1488c598ff7b461c4d9cecad57ef708f9b",
+        "rev": "e2a77a54a35642dd95310effe2bf4e36fff3af26",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                         | Commit Message                                              |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`e2a77a54`](https://github.com/nvim-telescope/telescope.nvim/commit/e2a77a54a35642dd95310effe2bf4e36fff3af26) | `doc: use correct option name for 'only_sort_text' (#1995)` |