### PR TITLE
chore(flake/nvim-lspconfig-src): `4eac16e8` -> `86f9c29b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -660,11 +660,11 @@
     "nvim-lspconfig-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654781732,
-        "narHash": "sha256-M2Cj/rYwv/3F3Chfp1zZ+cTwR9JIANSM7t6EcYuXF2o=",
+        "lastModified": 1655055452,
+        "narHash": "sha256-pBx5PAemFivVH12NtkkTZpqndYQNE8H2CnAdta3DUaw=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "4eac16e87f24ad26738e632446e29766e87141ae",
+        "rev": "86f9c29b4091bcc1cccb47e8208c470c4edf2ab1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                 | Commit Message                                                  |
| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------- |
| [`86f9c29b`](https://github.com/neovim/nvim-lspconfig/commit/86f9c29b4091bcc1cccb47e8208c470c4edf2ab1) | `docs: update server_configurations.md`                         |
| [`7a9c0485`](https://github.com/neovim/nvim-lspconfig/commit/7a9c0485456b58ad0eb1e138030f12a4d4d29e96) | `fix(purescript-language-server): root dir for Nix files #1954` |