### PR TITLE
chore(flake/fidget-src): `37d536bb` -> `46d11104`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -231,11 +231,11 @@
     "fidget-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1653063468,
-        "narHash": "sha256-0Z2fIEqDQzR8iNQtX+J7qE8TVg7xhvenYbUdOkUPC/g=",
+        "lastModified": 1655066771,
+        "narHash": "sha256-eX226T/678fWC7Ph+J/LgeKlDxJHdcTBXVwjJOS3Emw=",
         "owner": "j-hui",
         "repo": "fidget.nvim",
-        "rev": "37d536bbbee47222ddfeca0e8186e8ee6884f9a2",
+        "rev": "46d1110435f1f023c22fa95bb10b3906aecd7bde",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                             | Commit Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------------- |
| [`46d11104`](https://github.com/j-hui/fidget.nvim/commit/46d1110435f1f023c22fa95bb10b3906aecd7bde) | `Add filetype option to buffer (#85)` |