### PR TITLE
chore(flake/null-ls-nvim-src): `dfdd5fab` -> `96b0a6f0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -580,11 +580,11 @@
     "null-ls-nvim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654915948,
-        "narHash": "sha256-ekawl6TREZ7Vxc3r3vjjmNzxMvcXNjNi45T3WyYg3ps=",
+        "lastModified": 1655071554,
+        "narHash": "sha256-123ahOIR1UutuJfOzNV/TM6igVQ29Gb+NpPRBhQJ4Mc=",
         "owner": "jose-elias-alvarez",
         "repo": "null-ls.nvim",
-        "rev": "dfdd5fab3c53c30f83c78ea351b9a8f65715a5b7",
+        "rev": "96b0a6f02f1f4aaec83afb0826ae52733590d329",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                           | Commit Message                                      |
| ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`96b0a6f0`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/96b0a6f02f1f4aaec83afb0826ae52733590d329) | `chore: autogen metadata and docs`                  |
| [`4b4e1093`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/4b4e109391b8dcfdb3daa238f142bb91c51bc37a) | `feat(builtins): add blue formatter`                |
| [`a501dfdc`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/a501dfdc985be4b26fbe40958e1a4e1e400c3aea) | `chore: remove unused variable`                     |
| [`67e91334`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/67e91334f2d7e3f652595e260c8750056af67482) | `fix(cache): handle nil return value from callback` |
| [`e1c9b232`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/e1c9b2321ece7adb8c16fb93cabea9381ebae1f5) | `fix(cache): fix check for existing cache value`    |