### PR TITLE
chore(flake/plenary-nvim-src): `9c3239bc` -> `968a4b9a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -708,11 +708,11 @@
     "plenary-nvim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654718185,
-        "narHash": "sha256-MKKs4gsv6DUZsW4VMb35CD5aSWEj3k1DXhwpVTBEJLU=",
+        "lastModified": 1655062860,
+        "narHash": "sha256-pZ/x59dlSy4STWttE7wZMiVY2+vMY33FYpICk76FqRc=",
         "owner": "nvim-lua",
         "repo": "plenary.nvim",
-        "rev": "9c3239bc5f99b85be1123107f7290d16a68f8e64",
+        "rev": "968a4b9afec0c633bc369662e78f8c5db0eba249",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                 | Commit Message                                           |
| ------------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`968a4b9a`](https://github.com/nvim-lua/plenary.nvim/commit/968a4b9afec0c633bc369662e78f8c5db0eba249) | `fix(tests): switch to macos compatible commands (#375)` |