### PR TITLE
chore(flake/nixpkgs-master): `37b6b161` -> `29d09efb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1655087213,
-        "narHash": "sha256-4R5oQ+OwGAAcXWYrxC4gFMTUSstGxaN8kN7e8hkum/8=",
+        "lastModified": 1655168708,
+        "narHash": "sha256-HT1mTSvnQZs+JUqE4xsswePqoOhOUeWNJhnLM0l17lk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "37b6b161e536fddca54424cf80662bce735bdd1e",
+        "rev": "29d09efbd5daa65b97502647435c4c651478a10a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`08318d0a`](https://github.com/NixOS/nixpkgs/commit/08318d0ab7730d7424face713bec4936cfd7be5a) | `strawberry: 1.0.4 -> 1.0.5`                                              |
| [`99647e7a`](https://github.com/NixOS/nixpkgs/commit/99647e7a12b870c97303d437898cd33562183b7c) | `direnv: 2.31.0 -> 2.32.0`                                                |
| [`a6da7aad`](https://github.com/NixOS/nixpkgs/commit/a6da7aad396e24fc103f4d47ec0da5798d6e2463) | `python310Packages.azure-mgmt-logic: disable on older Python releases`    |
| [`afb6182f`](https://github.com/NixOS/nixpkgs/commit/afb6182f9a3f3b14eb63a250e4b6fb2f4ad7efd3) | `libnfc: specify license`                                                 |
| [`222fe563`](https://github.com/NixOS/nixpkgs/commit/222fe563b95464cea880334603dc313ae79b759b) | `palemoon: Limit build cores count`                                       |
| [`b1ff292b`](https://github.com/NixOS/nixpkgs/commit/b1ff292b1a9f3d875388455ae4eff4858f6dcc69) | `nixos/tests/jellyfin: fix type errors in test script`                    |
| [`1f31dbf1`](https://github.com/NixOS/nixpkgs/commit/1f31dbf1ec76d986d56c7c5391245e7bf0ba44d6) | `ocamlPackages.cry: 0.6.5 -> 0.6.7`                                       |
| [`38c776b6`](https://github.com/NixOS/nixpkgs/commit/38c776b6799195fae58808b19d9b19d198ca2896) | `stdenv/check-meta: support NIXPKGS_ALLOW_NONSOURCE=0`                    |
| [`df9425f1`](https://github.com/NixOS/nixpkgs/commit/df9425f1b2071837a7212cfd199b2caf99eda9cf) | `etcher: mark meta.sourceProvenance`                                      |
| [`cce03bad`](https://github.com/NixOS/nixpkgs/commit/cce03bad2d18f7912c0ce9ca2b8c819c3a8d464e) | `signal-desktop: mark meta.sourceProvenance`                              |
| [`0ca71677`](https://github.com/NixOS/nixpkgs/commit/0ca71677b4dd036f6294da21b0d34543cf2ae294) | `electron: mark meta.sourceProvenance`                                    |
| [`2c7a74c9`](https://github.com/NixOS/nixpkgs/commit/2c7a74c9925187476c7cd4f5dd227742b0c9a19a) | `vimPlugins.lspcontainers: init`                                          |
| [`8722479f`](https://github.com/NixOS/nixpkgs/commit/8722479fd45611b9827850965653c49ddfdc79e8) | `aws-iam-authenticator: fix ldflags`                                      |
| [`41d033fc`](https://github.com/NixOS/nixpkgs/commit/41d033fc50f59caeb58f1facdf5cd6ddb3947e48) | `watchlog: init at 1.152.0`                                               |
| [`4ecbbe38`](https://github.com/NixOS/nixpkgs/commit/4ecbbe38052e2d99884c4ac2422905c0032cdb7c) | `atomic-operator: init at 0.8.5`                                          |
| [`ee4b07bd`](https://github.com/NixOS/nixpkgs/commit/ee4b07bdd0f05059a0c2c12870d08ee70574dfc2) | `python310Packages.pick. init at 1.2.0`                                   |
| [`9e603ba5`](https://github.com/NixOS/nixpkgs/commit/9e603ba5f13c6da2948fd949f51dd7e47ba18a0f) | `mitmproxy2swagger: init at 0.6.0`                                        |
| [`64305297`](https://github.com/NixOS/nixpkgs/commit/64305297adc748610ac3b3e75ce6303e9622101e) | `python310Packages.json-stream: init at 1.3.0`                            |
| [`3cd7e5c7`](https://github.com/NixOS/nixpkgs/commit/3cd7e5c783945d4246e2e58f2c5e827cc3f97d3e) | `python310Packages.dvclive: 0.8.2 -> 0.9.0`                               |
| [`07ab3e4d`](https://github.com/NixOS/nixpkgs/commit/07ab3e4dc885040fc099102e8cd072e1f2d4f598) | `python310Packages.dvc-render: 0.0.5 -> 0.0.6`                            |
| [`b8df14ae`](https://github.com/NixOS/nixpkgs/commit/b8df14aec0a7ee98eb54dd8e476910cce7718f0c) | `tests/terminal-emulators: comply with mypy typecheck`                    |
| [`f74debc9`](https://github.com/NixOS/nixpkgs/commit/f74debc95fcca5f7a9b0ae3e31335e5bdefe062d) | `dnsdist: 1.7.0 -> 1.7.1`                                                 |
| [`02cd4871`](https://github.com/NixOS/nixpkgs/commit/02cd48717d5249876b181cf9555a48041dd33ae7) | `nixos/openldap: fix systemd rejecting notification (#177084)`            |
| [`a1ad2357`](https://github.com/NixOS/nixpkgs/commit/a1ad23574310f0ca7aedd916192855a3e2a46729) | `vimUtils: deprecate configure.pathogen (#154814)`                        |
| [`44248105`](https://github.com/NixOS/nixpkgs/commit/442481052a4819cdba2c7acce0f9e6ac45ae1475) | `libnfc: fix build on darwin`                                             |
| [`e1a1cfb5`](https://github.com/NixOS/nixpkgs/commit/e1a1cfb56504d1b82a3953bfb0632b37a1ca8d30) | `vimPlugins.fzf-hoogle-vim: init at 2022-05-01 (#176722)`                 |
| [`877b86fb`](https://github.com/NixOS/nixpkgs/commit/877b86fb372fee841f34f9ae3413808d869dc1b1) | `python310Packages.pyinsteon: 1.1.0 -> 1.1.1`                             |
| [`693d5359`](https://github.com/NixOS/nixpkgs/commit/693d5359ee0bfc1de975845f3a9f8f81a7abc535) | `oh-my-zsh: 2022-06-06 -> 2022-06-12 (#177485)`                           |
| [`3cf3911f`](https://github.com/NixOS/nixpkgs/commit/3cf3911f79abb0c1db989f0c2d8da3b6cea57bc5) | `python310Packages.azure-mgmt-logic: 9.0.0 -> 10.0.0`                     |
| [`f5389ce1`](https://github.com/NixOS/nixpkgs/commit/f5389ce140f4525942161ce2c8f1d99912962764) | `vscodium: mark meta.sourceProvenance`                                    |
| [`7cb9bf19`](https://github.com/NixOS/nixpkgs/commit/7cb9bf19b95a0068286d7f2d046ec4778ba47546) | `yandex-browser: mark meta.sourceProvenance`                              |
| [`6a0ed325`](https://github.com/NixOS/nixpkgs/commit/6a0ed325e334373ae903b8829f4074c0b3e2aed8) | `vivaldi: mark meta.sourceProvenance`                                     |
| [`746ecffa`](https://github.com/NixOS/nixpkgs/commit/746ecffadecd64faf8b62727ec295c037445851a) | `microsoft-edge: mark meta.sourceProvenance`                              |
| [`51d4989c`](https://github.com/NixOS/nixpkgs/commit/51d4989cdd46417597bd0d51b0e12af9e2e72059) | `firefox-bin: mark meta.sourceProvenance`                                 |
| [`76b1ca1c`](https://github.com/NixOS/nixpkgs/commit/76b1ca1c35d6973686579934591dc7a7517499f5) | `google-chrome: mark meta.sourceProvenance`                               |
| [`08947f3d`](https://github.com/NixOS/nixpkgs/commit/08947f3df6f020bc1e009261bea898545a9f7d80) | `opera: mark meta.sourceProvenance`                                       |
| [`c08c35ce`](https://github.com/NixOS/nixpkgs/commit/c08c35ced37f0d0f48874357afdc6b192d1e4c1f) | `adoptopenjdk-bin: mark meta.sourceProvenance`                            |
| [`f92bbd5b`](https://github.com/NixOS/nixpkgs/commit/f92bbd5b0ad78b5485fb101769e91ef8a792730d) | `breitbandmessung: mark meta.sourceProvenance`                            |
| [`6603e6a8`](https://github.com/NixOS/nixpkgs/commit/6603e6a8d11e2db76f507b54b0b6df2d9b9143e3) | `tor-browser-bundle-bin: mark meta.sourceProvenance`                      |
| [`04f2eb1b`](https://github.com/NixOS/nixpkgs/commit/04f2eb1b0af899d4b85d58dc9d05b74064701ac5) | `mathematica: mark meta.sourceProvenance`                                 |
| [`857463a4`](https://github.com/NixOS/nixpkgs/commit/857463a4650271625863d51143d85185e861a18d) | `trilium-{desktop,server}: mark meta.sourceProvenance`                    |
| [`d339c458`](https://github.com/NixOS/nixpkgs/commit/d339c458150b99b47769c7ca163fd65b5d3af06c) | `catt: 0.12.2 -> 0.12.7`                                                  |
| [`5e7840d6`](https://github.com/NixOS/nixpkgs/commit/5e7840d676d48d9a57a93b3115cdebe7317c46a9) | `clair: 4.4.2 -> 4.4.4`                                                   |
| [`accc92f0`](https://github.com/NixOS/nixpkgs/commit/accc92f06057c8653969d77389a39fe7bfaebde0) | `element-{web,desktop}: 1.10.13 -> 1.10.14`                               |
| [`695fe7d2`](https://github.com/NixOS/nixpkgs/commit/695fe7d25305da01262482bb2c6fc62abc81ac06) | `kubeaudit: 0.17.0 -> 0.18.0`                                             |
| [`edd50437`](https://github.com/NixOS/nixpkgs/commit/edd50437bdc9603c6318543162a607e1ff6fb0fa) | `checkov: 2.0.1209 -> 2.0.1210`                                           |
| [`fa733534`](https://github.com/NixOS/nixpkgs/commit/fa7335347aee4351b91fe144376fbcc0c0795e61) | `httpx: 1.2.1 -> 1.2.2`                                                   |
| [`94cb803f`](https://github.com/NixOS/nixpkgs/commit/94cb803fab0cbab18a57488f4ec39cfe038c734a) | `broadcom_sta: fix build on linux 5.18 (#177243)`                         |
| [`61d89863`](https://github.com/NixOS/nixpkgs/commit/61d8986385a22703d60c93c9965813d2a9a02d1f) | `coqPackages.{hierarchy-builder,trakt}: disable for Coq ≥ 8.16`           |
| [`10f159ff`](https://github.com/NixOS/nixpkgs/commit/10f159ffd14d966502e9fa6f0d74796e060e8574) | `coqPackages.mathcomp: disable for Coq ≥ 8.16`                            |
| [`476cb5b0`](https://github.com/NixOS/nixpkgs/commit/476cb5b0c7562a359fc0d55ea37118433b334962) | `coqPackages.simple-io: enable for Coq 8.16`                              |
| [`31648f5f`](https://github.com/NixOS/nixpkgs/commit/31648f5f8e2907a2f10d44ff291413b2de75d42d) | `coqPackages.StructTact: enable for Coq 8.16`                             |
| [`bd84a729`](https://github.com/NixOS/nixpkgs/commit/bd84a72970177184e90120ecc89ad5a380b28eda) | `coqPackages.coqprime: enable for Coq 8.16`                               |
| [`e488c3e8`](https://github.com/NixOS/nixpkgs/commit/e488c3e8347f749829495dc94412408f53524a5e) | `coqPackages.coq-record-update: enable for Coq 8.16`                      |
| [`7d148282`](https://github.com/NixOS/nixpkgs/commit/7d14828292694959ac4223527e04f6f3e85d694d) | `coqPackages.LibHyps: enable for Coq 8.16`                                |
| [`e09c29e9`](https://github.com/NixOS/nixpkgs/commit/e09c29e9e6f9ce3136345c95c1be463bff78d899) | `coqPackages.ITree: enable for Coq 8.16`                                  |
| [`8bdc1014`](https://github.com/NixOS/nixpkgs/commit/8bdc10141427cff137814050dbf8822a8ee83ac3) | `coqPackages.math-classes: enable for Coq 8.16`                           |
| [`577c9988`](https://github.com/NixOS/nixpkgs/commit/577c99884d4b01b1ee5ff48b215c2dfeca559948) | `coqPackages.metalib: enable for Coq 8.16`                                |
| [`80fd9ab1`](https://github.com/NixOS/nixpkgs/commit/80fd9ab13ec73c1a6bab5a4e9aab6286a2b69e81) | `coqPackages.parsec: enable for Coq 8.16`                                 |
| [`b03dc538`](https://github.com/NixOS/nixpkgs/commit/b03dc538a394a7011896eb9daa72ed5175cb5bc9) | `coqPackages.semantics: enable for Coq 8.16`                              |
| [`082dc9ab`](https://github.com/NixOS/nixpkgs/commit/082dc9aba9a880b8846809c88c5b13830df3eb77) | `coqPackages.iris: enable for Coq 8.16`                                   |
| [`591f2809`](https://github.com/NixOS/nixpkgs/commit/591f28097863d4f54b8ef987e5ed8cd70d23a2d5) | `coqPackages.stdpp: enable for Coq 8.16`                                  |
| [`ecb1e2a9`](https://github.com/NixOS/nixpkgs/commit/ecb1e2a99b6e81357e65ffebda3e09e3920c6c60) | `coqPackages.CoLoR: enable for Coq 8.16`                                  |
| [`a8392b2e`](https://github.com/NixOS/nixpkgs/commit/a8392b2ee4f99246eddf7f3e759131a666207a52) | `coqPackages.tlc: enable for Coq 8.16`                                    |
| [`b8e366f1`](https://github.com/NixOS/nixpkgs/commit/b8e366f1a44c6fe1ec744cc712ff3d66b1cc2630) | `coqPackages.paco: enable for Coq 8.16`                                   |
| [`3d80ca27`](https://github.com/NixOS/nixpkgs/commit/3d80ca27c09ae0187c0aedc9cb152205eb8ff222) | `coqPackages.coq-ext-lib: enable for Coq 8.16`                            |
| [`ccad0503`](https://github.com/NixOS/nixpkgs/commit/ccad0503ba519acda6647e439ab8555cd44e5c4e) | `python310Packages.pysmb: add format`                                     |
| [`75a0709f`](https://github.com/NixOS/nixpkgs/commit/75a0709f6733ae627998eb718f2a4602c0cff1b7) | `luaPackages.busted: install shell completion via installShellCompletion` |
| [`dd9df750`](https://github.com/NixOS/nixpkgs/commit/dd9df750ba87f19b3f3b205caf9011d1447d59b9) | `luaPackages.readline: fix build`                                         |
| [`83313fee`](https://github.com/NixOS/nixpkgs/commit/83313fee5c44199ad96f4cac9526f5b514f9f93b) | `luaPackages.lua-lsp: fixed build`                                        |
| [`98f9f1f0`](https://github.com/NixOS/nixpkgs/commit/98f9f1f05447a3fd97af44c2702ca71554ddfac2) | `luaPackages.luv: fix build`                                              |
| [`98a90f08`](https://github.com/NixOS/nixpkgs/commit/98a90f08913202940121d0e7e85cdf11c5a1bc0e) | `luaPackages: update`                                                     |
| [`fb6f9ee2`](https://github.com/NixOS/nixpkgs/commit/fb6f9ee28ff6c57f4ab697a1db782e89a744f547) | `update-luarocks-package: fix mirrors`                                    |
| [`77a0e5f3`](https://github.com/NixOS/nixpkgs/commit/77a0e5f36e758ec62354919bd4dcc28b9eeebe3c) | `luarocks: 3.8.0 -> 3.9.0`                                                |
| [`022562fc`](https://github.com/NixOS/nixpkgs/commit/022562fcf01b5e4abdf1018e7f0eab401c0d9258) | `offensive-azure: init at 0.4.10`                                         |
| [`436a7e33`](https://github.com/NixOS/nixpkgs/commit/436a7e33b6b07a3208c199eebc5a344b266d9137) | `python310Packages.pysmb: 1.2.7 -> 1.2.8`                                 |
| [`ee0c2902`](https://github.com/NixOS/nixpkgs/commit/ee0c29026ad4f5fa88ff1e1c4f358bb6b07a9d45) | `crlfsuite: init at 2.0`                                                  |
| [`56434c72`](https://github.com/NixOS/nixpkgs/commit/56434c7266f654fc366de13d69d8cf75d462adf1) | `home-assistant: update component-packages`                               |
| [`f4ab2ad0`](https://github.com/NixOS/nixpkgs/commit/f4ab2ad06f2e6de0728853f153364d619e582470) | `python310Packages.pycketcasts: init at 1.0.1`                            |
| [`1cd4b21e`](https://github.com/NixOS/nixpkgs/commit/1cd4b21e0744ffa775b50d7c76e36cff761d6496) | `smbscan: init at unstable-2022-05-26`                                    |
| [`77248491`](https://github.com/NixOS/nixpkgs/commit/772484911ca7a5cc71eac4a30395b8bf62f71d9e) | `python310Packages.aiohue: 4.4.1 -> 4.4.2`                                |
| [`d7500fd8`](https://github.com/NixOS/nixpkgs/commit/d7500fd8ef428c3c13b5e35644c0590b9e124eec) | `dnsrecon: 1.1.0 -> 1.1.1`                                                |
| [`1f980689`](https://github.com/NixOS/nixpkgs/commit/1f9806891d18c3f984e41f56fe0cc4458ee01e29) | `dnsrecon: 1.0.0 -> 1.1.0`                                                |
| [`de00076f`](https://github.com/NixOS/nixpkgs/commit/de00076fa30e56547130e582a1cceb8f9a040caf) | `libsForQt5.kimageannotator: 0.5.3 -> 0.6.0`                              |
| [`bc1f4d29`](https://github.com/NixOS/nixpkgs/commit/bc1f4d29b10ede9cc9bdf41afbdf0c1bb074f64b) | `libsForQt5.kcolorpicker: 0.1.6 -> 0.2.0`                                 |
| [`0105fbfc`](https://github.com/NixOS/nixpkgs/commit/0105fbfc7189e1b13973e4c8c3eb1714f611ae51) | `python310Packages.bond-async: 0.1.20 -> 0.1.22`                          |
| [`6b24ace7`](https://github.com/NixOS/nixpkgs/commit/6b24ace792dce64d2ddd3cfab3862ba23304bd31) | `python310Packages.unicrypto: 0.0.7 -> 0.0.8`                             |
| [`64fb3fcc`](https://github.com/NixOS/nixpkgs/commit/64fb3fccb8783000c0ea5e12c075e733d7d1e50e) | `python310Packages.peaqevcore: 0.4.7 -> 1.0.11`                           |
| [`fe8817a6`](https://github.com/NixOS/nixpkgs/commit/fe8817a65eeb8811a95e43afec419a8818bd3013) | `python310Packages.ssh-mitm: 2.0.3 -> 2.0.4`                              |
| [`910932a1`](https://github.com/NixOS/nixpkgs/commit/910932a1d88c39dfb1be1f5955f14d93479b4053) | `flexget: 3.3.15 -> 3.3.16`                                               |
| [`e3f6c194`](https://github.com/NixOS/nixpkgs/commit/e3f6c1944390133c9223f7c1aa8af5cdc999149d) | `clojure: 1.11.1.1124 -> 1.11.1.1129`                                     |
| [`1a96f49e`](https://github.com/NixOS/nixpkgs/commit/1a96f49e8df0345b8fa3364fa50397ddfa61020b) | `msmtp: 1.8.19 -> 1.8.20`                                                 |
| [`24a1360b`](https://github.com/NixOS/nixpkgs/commit/24a1360b9767c22358e00b95fc56c717d51b7cf9) | `python3Packages.aioimaplib: support Python 3.10`                         |
| [`df0b326d`](https://github.com/NixOS/nixpkgs/commit/df0b326d754b4385eaea9e470da19ac603754200) | `grafana: 8.5.3 -> 8.5.5`                                                 |
| [`186ba212`](https://github.com/NixOS/nixpkgs/commit/186ba212b5ca0eddf74571b72abf2033c1bd4fbd) | `wiki-js: 2.5.283 -> 2.5.284`                                             |
| [`e03d41fb`](https://github.com/NixOS/nixpkgs/commit/e03d41fb6bb3076a4a868f173cb4019e4e92a816) | `nixos/prometheus-wireguard-exporter: fix broken options`                 |
| [`4b1055d9`](https://github.com/NixOS/nixpkgs/commit/4b1055d9409e0e120474d1c287c6055438768799) | `python310Packages.zwave-js-server-python: 0.37.1 -> 0.37.2`              |
| [`8be5ecd6`](https://github.com/NixOS/nixpkgs/commit/8be5ecd6e394905a36c1c48a2408e124ef5d38a2) | `python310Packages.ansible-doctor: 1.3.0 -> 1.4.0`                        |
| [`8b5f4cf6`](https://github.com/NixOS/nixpkgs/commit/8b5f4cf64269389bd865ed45981eaf726ae3f61d) | `python310Packages.ansible-later: 2.0.13 -> 2.0.14`                       |
| [`cdc03841`](https://github.com/NixOS/nixpkgs/commit/cdc038410982b26c6519ef445c9f30812223eb59) | `python310Packages.ultraheat-api: init at 0.4.0`                          |
| [`d8ba6b40`](https://github.com/NixOS/nixpkgs/commit/d8ba6b400be7cfd4a1a6ae6bc3de7cba7f215d51) | `dynamips: 0.2.21 -> 0.2.22`                                              |
| [`172a1d93`](https://github.com/NixOS/nixpkgs/commit/172a1d93973a7ac6371ad63f8fe2e46f7e7ef3d9) | `bundler-audit: 0.9.0.1 -> 0.9.1`                                         |
| [`d77c1d5c`](https://github.com/NixOS/nixpkgs/commit/d77c1d5c85f7afdf6f1efda9ddd3de7cb6623314) | `dmarc-metrics-exporter: 0.5.1 -> 0.6.0`                                  |
| [`e6912f3a`](https://github.com/NixOS/nixpkgs/commit/e6912f3a94945a71c88d48c2669f7ce53da8c3d8) | `python310Packages.bite-parser: 0.1.1 -> 0.1.3`                           |
| [`b0e09fde`](https://github.com/NixOS/nixpkgs/commit/b0e09fdea3ec0eb9b1a273a01a830a7677808f44) | `jellyfin: 10.7.7 -> 10.8.0`                                              |
| [`be8ccf1b`](https://github.com/NixOS/nixpkgs/commit/be8ccf1bf251b4123051d3217a504539f034119a) | `jellyfin-web: 10.7.7 -> 10.8.0`                                          |
| [`4e38070d`](https://github.com/NixOS/nixpkgs/commit/4e38070d6ae8bda38b7ac03cb5ca0849761c7c2d) | `diffoscope: 215 -> 216`                                                  |
| [`4bdf850d`](https://github.com/NixOS/nixpkgs/commit/4bdf850d1b42a6f3e93fb767ffada5c55cf24fdf) | `python3Packages.mysql-connector: allow use of clang for darwin`          |
| [`7da38d0f`](https://github.com/NixOS/nixpkgs/commit/7da38d0f4a2b03dc5182e65a5bd87c45837ef55d) | `pythonPackages.myst-parser: init at 0.18.0`                              |
| [`737da091`](https://github.com/NixOS/nixpkgs/commit/737da0915746fa4a297e7cd6d66e34126d190ee1) | `pythonPackages.pytest-param-files: init at 0.3.4`                        |
| [`eafcfbf6`](https://github.com/NixOS/nixpkgs/commit/eafcfbf6e5af2916cb5689d4927647a57ce71175) | `pythonPackages.sphinx-pytest: init at 0.0.3`                             |
| [`92d8ebcd`](https://github.com/NixOS/nixpkgs/commit/92d8ebcd0d42ca1982258ac8e155482a97e18677) | `neil: 0.0.23 -> 0.0.31`                                                  |
| [`b39d5e81`](https://github.com/NixOS/nixpkgs/commit/b39d5e81b168acde8555a6ccbcb937268945a7dd) | `python310Packages.pyunifiprotect: 3.9.1 -> 3.9.2`                        |
| [`35f3cb8c`](https://github.com/NixOS/nixpkgs/commit/35f3cb8c6e2e08fec29209d096733d7cc68dc655) | `xorg.xf86videoxgi: pull upstream fix for -fno-common toolchains`         |
| [`dfbb9600`](https://github.com/NixOS/nixpkgs/commit/dfbb960094c6136dd7fe2829427bd5af6d97f7ce) | `tvheadend: pull upstream fix for -fno-common toolchains`                 |
| [`ce5eca92`](https://github.com/NixOS/nixpkgs/commit/ce5eca92f157e9f4fc7c2f5566fc2f8beff14d0a) | `rocksndiamonds: pull upstream fix for -fno-common toolchains`            |
| [`1ee09a25`](https://github.com/NixOS/nixpkgs/commit/1ee09a25e808abf4d8d65f3900ba6aef2cd028b6) | `neverball: pull upstream fix for -fno-common toolchains`                 |
| [`7762092a`](https://github.com/NixOS/nixpkgs/commit/7762092a32b66f53ee828a99f5d192a81acf24af) | `vimPlugins.nvim-lastplace: init at 2021-10-15`                           |
| [`e5a1277c`](https://github.com/NixOS/nixpkgs/commit/e5a1277cf6e50263834fa5cfff430bc9173f1acc) | `vimPlugins: update`                                                      |
| [`f68dd75e`](https://github.com/NixOS/nixpkgs/commit/f68dd75e0b99cf4d4f264758fec900323fd01719) | `python310Packages.pyunifiprotect: 3.9.0 -> 3.9.1`                        |
| [`f3ed3e29`](https://github.com/NixOS/nixpkgs/commit/f3ed3e29aaed442f7954e8c5e5f2b886c00733fb) | `python310Packages.azure-eventhub: 5.9.0 -> 5.10.0`                       |
| [`0b7397aa`](https://github.com/NixOS/nixpkgs/commit/0b7397aadb5b1cc71da9003f3c68984c3a1216ee) | `spdx-license-list-data: 3.16 -> 3.17`                                    |
| [`b05ee647`](https://github.com/NixOS/nixpkgs/commit/b05ee6474a6e232bb0840654e1af86abd0cdf3da) | `python310Packages.azure-servicebus: 7.6.1 -> 7.7.0`                      |
| [`87c7d13b`](https://github.com/NixOS/nixpkgs/commit/87c7d13b22aa0518f7369aeac24894cc21d52396) | `python310Packages.pyunifiprotect: 3.8.0 -> 3.9.0`                        |
| [`d6f80617`](https://github.com/NixOS/nixpkgs/commit/d6f80617a3e667ddc89f2f450c7909873bfb18f6) | `manul: remove`                                                           |
| [`81291cc7`](https://github.com/NixOS/nixpkgs/commit/81291cc793cf88bd6eff3fd8512e5eb9d037066c) | `nixos/grafana: Allow setting UID for datasource`                         |