### PR TITLE
chore(flake/nvim-lspconfig-src): `86f9c29b` -> `650ce715`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -660,11 +660,11 @@
     "nvim-lspconfig-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1655055452,
-        "narHash": "sha256-pBx5PAemFivVH12NtkkTZpqndYQNE8H2CnAdta3DUaw=",
+        "lastModified": 1655109930,
+        "narHash": "sha256-E9BqEkm2wyQPJfSJEKZ5+AKk5A0tvjX0sGkIBgEJCfI=",
         "owner": "neovim",
         "repo": "nvim-lspconfig",
-        "rev": "86f9c29b4091bcc1cccb47e8208c470c4edf2ab1",
+        "rev": "650ce7156ca7935e02934eef45b392957ea402e8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                 | Commit Message                              |
| ------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
| [`650ce715`](https://github.com/neovim/nvim-lspconfig/commit/650ce7156ca7935e02934eef45b392957ea402e8) | `docs: update server_configurations.md`     |
| [`4f94bf5b`](https://github.com/neovim/nvim-lspconfig/commit/4f94bf5ba90e97a9718e5a2eb57b0737e1bdd176) | `docs: unverbose, mention "settings" param` |