### PR TITLE
chore(flake/nixpkgs): `72b1ec0a` -> `e1a1cfb5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -464,11 +464,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655034456,
-        "narHash": "sha256-HXXyvGqZLa+2u8IPIRm/uNQiw+gBtTNu58YaXMJtKRc=",
+        "lastModified": 1655122334,
+        "narHash": "sha256-Rwwvo9TDCH0a4m/Jvoq5wZ3FLSLiVLBD1FFfN/3XawA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "72b1ec0a79b1fc50f6cc0694c2f0b1eb384a932e",
+        "rev": "e1a1cfb56504d1b82a3953bfb0632b37a1ca8d30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                                                                         |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
| [`e1a1cfb5`](https://github.com/NixOS/nixpkgs/commit/e1a1cfb56504d1b82a3953bfb0632b37a1ca8d30) | `vimPlugins.fzf-hoogle-vim: init at 2022-05-01 (#176722)`                                                              |
| [`693d5359`](https://github.com/NixOS/nixpkgs/commit/693d5359ee0bfc1de975845f3a9f8f81a7abc535) | `oh-my-zsh: 2022-06-06 -> 2022-06-12 (#177485)`                                                                        |
| [`f5389ce1`](https://github.com/NixOS/nixpkgs/commit/f5389ce140f4525942161ce2c8f1d99912962764) | `vscodium: mark meta.sourceProvenance`                                                                                 |
| [`7cb9bf19`](https://github.com/NixOS/nixpkgs/commit/7cb9bf19b95a0068286d7f2d046ec4778ba47546) | `yandex-browser: mark meta.sourceProvenance`                                                                           |
| [`6a0ed325`](https://github.com/NixOS/nixpkgs/commit/6a0ed325e334373ae903b8829f4074c0b3e2aed8) | `vivaldi: mark meta.sourceProvenance`                                                                                  |
| [`746ecffa`](https://github.com/NixOS/nixpkgs/commit/746ecffadecd64faf8b62727ec295c037445851a) | `microsoft-edge: mark meta.sourceProvenance`                                                                           |
| [`51d4989c`](https://github.com/NixOS/nixpkgs/commit/51d4989cdd46417597bd0d51b0e12af9e2e72059) | `firefox-bin: mark meta.sourceProvenance`                                                                              |
| [`76b1ca1c`](https://github.com/NixOS/nixpkgs/commit/76b1ca1c35d6973686579934591dc7a7517499f5) | `google-chrome: mark meta.sourceProvenance`                                                                            |
| [`08947f3d`](https://github.com/NixOS/nixpkgs/commit/08947f3df6f020bc1e009261bea898545a9f7d80) | `opera: mark meta.sourceProvenance`                                                                                    |
| [`c08c35ce`](https://github.com/NixOS/nixpkgs/commit/c08c35ced37f0d0f48874357afdc6b192d1e4c1f) | `adoptopenjdk-bin: mark meta.sourceProvenance`                                                                         |
| [`f92bbd5b`](https://github.com/NixOS/nixpkgs/commit/f92bbd5b0ad78b5485fb101769e91ef8a792730d) | `breitbandmessung: mark meta.sourceProvenance`                                                                         |
| [`6603e6a8`](https://github.com/NixOS/nixpkgs/commit/6603e6a8d11e2db76f507b54b0b6df2d9b9143e3) | `tor-browser-bundle-bin: mark meta.sourceProvenance`                                                                   |
| [`04f2eb1b`](https://github.com/NixOS/nixpkgs/commit/04f2eb1b0af899d4b85d58dc9d05b74064701ac5) | `mathematica: mark meta.sourceProvenance`                                                                              |
| [`857463a4`](https://github.com/NixOS/nixpkgs/commit/857463a4650271625863d51143d85185e861a18d) | `trilium-{desktop,server}: mark meta.sourceProvenance`                                                                 |
| [`94cb803f`](https://github.com/NixOS/nixpkgs/commit/94cb803fab0cbab18a57488f4ec39cfe038c734a) | `broadcom_sta: fix build on linux 5.18 (#177243)`                                                                      |
| [`61d89863`](https://github.com/NixOS/nixpkgs/commit/61d8986385a22703d60c93c9965813d2a9a02d1f) | `coqPackages.{hierarchy-builder,trakt}: disable for Coq ≥ 8.16`                                                        |
| [`10f159ff`](https://github.com/NixOS/nixpkgs/commit/10f159ffd14d966502e9fa6f0d74796e060e8574) | `coqPackages.mathcomp: disable for Coq ≥ 8.16`                                                                         |
| [`476cb5b0`](https://github.com/NixOS/nixpkgs/commit/476cb5b0c7562a359fc0d55ea37118433b334962) | `coqPackages.simple-io: enable for Coq 8.16`                                                                           |
| [`31648f5f`](https://github.com/NixOS/nixpkgs/commit/31648f5f8e2907a2f10d44ff291413b2de75d42d) | `coqPackages.StructTact: enable for Coq 8.16`                                                                          |
| [`bd84a729`](https://github.com/NixOS/nixpkgs/commit/bd84a72970177184e90120ecc89ad5a380b28eda) | `coqPackages.coqprime: enable for Coq 8.16`                                                                            |
| [`e488c3e8`](https://github.com/NixOS/nixpkgs/commit/e488c3e8347f749829495dc94412408f53524a5e) | `coqPackages.coq-record-update: enable for Coq 8.16`                                                                   |
| [`7d148282`](https://github.com/NixOS/nixpkgs/commit/7d14828292694959ac4223527e04f6f3e85d694d) | `coqPackages.LibHyps: enable for Coq 8.16`                                                                             |
| [`e09c29e9`](https://github.com/NixOS/nixpkgs/commit/e09c29e9e6f9ce3136345c95c1be463bff78d899) | `coqPackages.ITree: enable for Coq 8.16`                                                                               |
| [`8bdc1014`](https://github.com/NixOS/nixpkgs/commit/8bdc10141427cff137814050dbf8822a8ee83ac3) | `coqPackages.math-classes: enable for Coq 8.16`                                                                        |
| [`577c9988`](https://github.com/NixOS/nixpkgs/commit/577c99884d4b01b1ee5ff48b215c2dfeca559948) | `coqPackages.metalib: enable for Coq 8.16`                                                                             |
| [`80fd9ab1`](https://github.com/NixOS/nixpkgs/commit/80fd9ab13ec73c1a6bab5a4e9aab6286a2b69e81) | `coqPackages.parsec: enable for Coq 8.16`                                                                              |
| [`b03dc538`](https://github.com/NixOS/nixpkgs/commit/b03dc538a394a7011896eb9daa72ed5175cb5bc9) | `coqPackages.semantics: enable for Coq 8.16`                                                                           |
| [`082dc9ab`](https://github.com/NixOS/nixpkgs/commit/082dc9aba9a880b8846809c88c5b13830df3eb77) | `coqPackages.iris: enable for Coq 8.16`                                                                                |
| [`591f2809`](https://github.com/NixOS/nixpkgs/commit/591f28097863d4f54b8ef987e5ed8cd70d23a2d5) | `coqPackages.stdpp: enable for Coq 8.16`                                                                               |
| [`ecb1e2a9`](https://github.com/NixOS/nixpkgs/commit/ecb1e2a99b6e81357e65ffebda3e09e3920c6c60) | `coqPackages.CoLoR: enable for Coq 8.16`                                                                               |
| [`a8392b2e`](https://github.com/NixOS/nixpkgs/commit/a8392b2ee4f99246eddf7f3e759131a666207a52) | `coqPackages.tlc: enable for Coq 8.16`                                                                                 |
| [`b8e366f1`](https://github.com/NixOS/nixpkgs/commit/b8e366f1a44c6fe1ec744cc712ff3d66b1cc2630) | `coqPackages.paco: enable for Coq 8.16`                                                                                |
| [`3d80ca27`](https://github.com/NixOS/nixpkgs/commit/3d80ca27c09ae0187c0aedc9cb152205eb8ff222) | `coqPackages.coq-ext-lib: enable for Coq 8.16`                                                                         |
| [`ccad0503`](https://github.com/NixOS/nixpkgs/commit/ccad0503ba519acda6647e439ab8555cd44e5c4e) | `python310Packages.pysmb: add format`                                                                                  |
| [`436a7e33`](https://github.com/NixOS/nixpkgs/commit/436a7e33b6b07a3208c199eebc5a344b266d9137) | `python310Packages.pysmb: 1.2.7 -> 1.2.8`                                                                              |
| [`56434c72`](https://github.com/NixOS/nixpkgs/commit/56434c7266f654fc366de13d69d8cf75d462adf1) | `home-assistant: update component-packages`                                                                            |
| [`f4ab2ad0`](https://github.com/NixOS/nixpkgs/commit/f4ab2ad06f2e6de0728853f153364d619e582470) | `python310Packages.pycketcasts: init at 1.0.1`                                                                         |
| [`de00076f`](https://github.com/NixOS/nixpkgs/commit/de00076fa30e56547130e582a1cceb8f9a040caf) | `libsForQt5.kimageannotator: 0.5.3 -> 0.6.0`                                                                           |
| [`bc1f4d29`](https://github.com/NixOS/nixpkgs/commit/bc1f4d29b10ede9cc9bdf41afbdf0c1bb074f64b) | `libsForQt5.kcolorpicker: 0.1.6 -> 0.2.0`                                                                              |
| [`0105fbfc`](https://github.com/NixOS/nixpkgs/commit/0105fbfc7189e1b13973e4c8c3eb1714f611ae51) | `python310Packages.bond-async: 0.1.20 -> 0.1.22`                                                                       |
| [`6b24ace7`](https://github.com/NixOS/nixpkgs/commit/6b24ace792dce64d2ddd3cfab3862ba23304bd31) | `python310Packages.unicrypto: 0.0.7 -> 0.0.8`                                                                          |
| [`64fb3fcc`](https://github.com/NixOS/nixpkgs/commit/64fb3fccb8783000c0ea5e12c075e733d7d1e50e) | `python310Packages.peaqevcore: 0.4.7 -> 1.0.11`                                                                        |
| [`fe8817a6`](https://github.com/NixOS/nixpkgs/commit/fe8817a65eeb8811a95e43afec419a8818bd3013) | `python310Packages.ssh-mitm: 2.0.3 -> 2.0.4`                                                                           |
| [`910932a1`](https://github.com/NixOS/nixpkgs/commit/910932a1d88c39dfb1be1f5955f14d93479b4053) | `flexget: 3.3.15 -> 3.3.16`                                                                                            |
| [`e3f6c194`](https://github.com/NixOS/nixpkgs/commit/e3f6c1944390133c9223f7c1aa8af5cdc999149d) | `clojure: 1.11.1.1124 -> 1.11.1.1129`                                                                                  |
| [`1a96f49e`](https://github.com/NixOS/nixpkgs/commit/1a96f49e8df0345b8fa3364fa50397ddfa61020b) | `msmtp: 1.8.19 -> 1.8.20`                                                                                              |
| [`24a1360b`](https://github.com/NixOS/nixpkgs/commit/24a1360b9767c22358e00b95fc56c717d51b7cf9) | `python3Packages.aioimaplib: support Python 3.10`                                                                      |
| [`beb707c4`](https://github.com/NixOS/nixpkgs/commit/beb707c4e6f454c084ae733a374f1efde5f4ad73) | `python3Packages.vqgan-jax: init at unstable-2022-04-20`                                                               |
| [`7527d536`](https://github.com/NixOS/nixpkgs/commit/7527d53617486517f4a6ce8f252ef549139c9633) | `python3Packages.dalle-mini: init at 0.1.0`                                                                            |
| [`e3dc5bf1`](https://github.com/NixOS/nixpkgs/commit/e3dc5bf1307611af889de1c9c98658f97e03a59a) | `authenticator: 4.1.2 -> 4.1.4`                                                                                        |
| [`9e8e5c78`](https://github.com/NixOS/nixpkgs/commit/9e8e5c785e23e71b34641b54b0141d92509cce69) | `python310Packages.rmcl: init at 0.4.2`                                                                                |
| [`77087c71`](https://github.com/NixOS/nixpkgs/commit/77087c710f7938649cbc240e79a593c52fb8b342) | `python310Packages.asks: init at 3.0.0`                                                                                |
| [`0a24fb2a`](https://github.com/NixOS/nixpkgs/commit/0a24fb2a96e791023287380ad92c8384ea9a7117) | `python310Packages.overly: init at 0.1.85`                                                                             |
| [`2aa3a9bb`](https://github.com/NixOS/nixpkgs/commit/2aa3a9bba018e8402677b528a6b787dd8dd791a2) | `python310Packages.sansio-multipart: init at 0.3`                                                                      |
| [`03daf984`](https://github.com/NixOS/nixpkgs/commit/03daf984411d1747c42722804cf20e3773bb56ce) | `python310Packages.rmrl: init at 0.2.1`                                                                                |
| [`0bb1beda`](https://github.com/NixOS/nixpkgs/commit/0bb1bedab16c0d5e6fbe0fec3b5fa7dc81296baa) | `python310Packages.svglib: use pytestCheckHook`                                                                        |
| [`e5860e40`](https://github.com/NixOS/nixpkgs/commit/e5860e40fd660232e5a1d2512d3f278bf366d795) | `python310Packages.greeclimate: 1.2.0 -> 1.2.1`                                                                        |
| [`dd1000d6`](https://github.com/NixOS/nixpkgs/commit/dd1000d608266b99f38460aca9f12b856ae0a4c7) | `python310Packages.nextcord: 2.0.0b2 -> 2.0.0b3`                                                                       |
| [`24375ea5`](https://github.com/NixOS/nixpkgs/commit/24375ea5727c44891ca437710aed0d565c48aa7b) | `python310Packages.pytest-annotate: 1.0.4 -> 1.0.5`                                                                    |
| [`2ecca8bd`](https://github.com/NixOS/nixpkgs/commit/2ecca8bd9e601ccef0b6d4c67e207d678f50835f) | `ooniprobe-cli: 3.15.0 -> 3.15.1`                                                                                      |
| [`dfe98e2c`](https://github.com/NixOS/nixpkgs/commit/dfe98e2c07079bd9aa320032613b4df5de6dc321) | `catch2: 2.13.8 -> 2.13.9`                                                                                             |
| [`fd0605d0`](https://github.com/NixOS/nixpkgs/commit/fd0605d0d2474fe7c7c8df7a469a988ef79c76cd) | `abcmidi: 2022.05.20 -> 2022.06.07`                                                                                    |
| [`df0b326d`](https://github.com/NixOS/nixpkgs/commit/df0b326d754b4385eaea9e470da19ac603754200) | `grafana: 8.5.3 -> 8.5.5`                                                                                              |
| [`cc73dc83`](https://github.com/NixOS/nixpkgs/commit/cc73dc83b36b76baab8bf2282c2e0fcc1ebbbd5a) | `Revert "nixos/security/wrappers: use an assertion for the existence check"`                                           |
| [`4ae57843`](https://github.com/NixOS/nixpkgs/commit/4ae57843bac2e041923ff8c308d722fb923e6906) | `ventoy-bin: 1.0.75 -> 1.0.76`                                                                                         |
| [`186ba212`](https://github.com/NixOS/nixpkgs/commit/186ba212b5ca0eddf74571b72abf2033c1bd4fbd) | `wiki-js: 2.5.283 -> 2.5.284`                                                                                          |
| [`e03d41fb`](https://github.com/NixOS/nixpkgs/commit/e03d41fb6bb3076a4a868f173cb4019e4e92a816) | `nixos/prometheus-wireguard-exporter: fix broken options`                                                              |
| [`4b1055d9`](https://github.com/NixOS/nixpkgs/commit/4b1055d9409e0e120474d1c287c6055438768799) | `python310Packages.zwave-js-server-python: 0.37.1 -> 0.37.2`                                                           |
| [`efc04d51`](https://github.com/NixOS/nixpkgs/commit/efc04d51febd184b3a743c87e53994aab383db06) | `python310Packages.xmlschema: 1.11.1 -> 1.11.2`                                                                        |
| [`8be5ecd6`](https://github.com/NixOS/nixpkgs/commit/8be5ecd6e394905a36c1c48a2408e124ef5d38a2) | `python310Packages.ansible-doctor: 1.3.0 -> 1.4.0`                                                                     |
| [`8b5f4cf6`](https://github.com/NixOS/nixpkgs/commit/8b5f4cf64269389bd865ed45981eaf726ae3f61d) | `python310Packages.ansible-later: 2.0.13 -> 2.0.14`                                                                    |
| [`b25f38ac`](https://github.com/NixOS/nixpkgs/commit/b25f38ac4e210f88aaf394471e11b002b79b11e2) | `krita: 5.0.6 -> 5.0.8`                                                                                                |
| [`c602569c`](https://github.com/NixOS/nixpkgs/commit/c602569c9de4d51bb1cd9d5f0c88c914cd183ae5) | `maintainers: add nek0`                                                                                                |
| [`74b3456a`](https://github.com/NixOS/nixpkgs/commit/74b3456a75de1510abf714dfa5097bcd65ca7ddc) | `vopono: 0.8.10 -> 0.9.1`                                                                                              |
| [`fd2a89b9`](https://github.com/NixOS/nixpkgs/commit/fd2a89b98330f4a06636ef19f34716d68ea7fe71) | ``nixos/wpa_supplicant: don't log that wpa_supplicant.conf is ignored with `allowAuxiliaryImperativeNetworks = true``` |
| [`cdc03841`](https://github.com/NixOS/nixpkgs/commit/cdc038410982b26c6519ef445c9f30812223eb59) | `python310Packages.ultraheat-api: init at 0.4.0`                                                                       |
| [`24a46503`](https://github.com/NixOS/nixpkgs/commit/24a46503dfe430dd3ad9fad1ac88da1de21436da) | `bluewalker: 0.3.0 -> 0.3.1`                                                                                           |
| [`09905953`](https://github.com/NixOS/nixpkgs/commit/099059530967f724cad3227716e53f5b57c393b3) | `rtl8821cu: 2022-03-08 -> 2022-05-07`                                                                                  |
| [`e17c1d5a`](https://github.com/NixOS/nixpkgs/commit/e17c1d5a52f1397bdecc2e0dc8d094aa081cbb1d) | `kodi.packages.urllib3: 1.26.4+matrix.1 -> 1.26.8+matrix.1`                                                            |
| [`f78374bf`](https://github.com/NixOS/nixpkgs/commit/f78374bfa5f0535f80dc5b0c8bf62072661381c4) | `python3Packages.afdko: skip broken test on armv7l (#177400)`                                                          |
| [`d6d847bc`](https://github.com/NixOS/nixpkgs/commit/d6d847bc396c9e0ab52a888d93a5e4fbac52c856) | `okteto: 2.3.1 -> 2.3.3`                                                                                               |
| [`324df04b`](https://github.com/NixOS/nixpkgs/commit/324df04b67cf92017138a13737e7500e67060eb0) | `linuxPackages: use 5_10 kernel on 32-bit platforms`                                                                   |
| [`dd63da94`](https://github.com/NixOS/nixpkgs/commit/dd63da9494c30dc7d13c16f6fe58673746592511) | `hwatch: init at 0.3.6`                                                                                                |
| [`1b9bacef`](https://github.com/NixOS/nixpkgs/commit/1b9baceff43bff11ca97dd1a89e6fc52e83c9058) | `python3Packages.uvloop: disable problematic test on armv7l too`                                                       |
| [`85a49d0a`](https://github.com/NixOS/nixpkgs/commit/85a49d0af879a7aecd7a01ea00a06cde5f38e936) | `python310Packages.plugwise: 0.19.0 -> 0.19.1`                                                                         |
| [`bf580b0e`](https://github.com/NixOS/nixpkgs/commit/bf580b0edebbd6d862749e545a740a33eb358169) | `python310Packages.asf-search: 3.0.6 -> 3.2.2`                                                                         |
| [`218093d3`](https://github.com/NixOS/nixpkgs/commit/218093d36a5846643a5fb8ba5abfcdec6d00de4c) | `python310Packages.wktutils: init at 1.1.4`                                                                            |
| [`67512331`](https://github.com/NixOS/nixpkgs/commit/67512331eb8317dd07982f39486f1f071ac0d3a1) | `python310Packages.kml2geojson: init at 5.1.0`                                                                         |
| [`872695d0`](https://github.com/NixOS/nixpkgs/commit/872695d02b9a8f23d7e0cca0ab6331039ca3c108) | `krita: fix double wrapping`                                                                                           |
| [`1785ce8d`](https://github.com/NixOS/nixpkgs/commit/1785ce8db1d7458f11788158263288fb2f94d40e) | `python310Packages.browser-cookie3: 0.14.2 -> 0.14.3`                                                                  |
| [`d5a87ede`](https://github.com/NixOS/nixpkgs/commit/d5a87edeab9fe4c3bdd85f14e230bddf86d88e03) | `buildMozillaMach: allow PGO on all Linux platforms`                                                                   |
| [`65666128`](https://github.com/NixOS/nixpkgs/commit/65666128992f73018e4cad71a7e96813f2031b19) | `sshfs: 3.7.2 -> 3.7.3`                                                                                                |
| [`8ae485e7`](https://github.com/NixOS/nixpkgs/commit/8ae485e75b352cd11bba96bc20d7e65913178054) | `python310Packages.entrypoint2: add format`                                                                            |
| [`9d84f435`](https://github.com/NixOS/nixpkgs/commit/9d84f435e351dfe89f5e7b1c7ca6f4cdb3fe06aa) | `nixVersions.nix_2_9: pull patch to add missing git-dir flags`                                                         |
| [`39a56c76`](https://github.com/NixOS/nixpkgs/commit/39a56c7696aee49ef0c6cf4747cc44097db79b84) | `nixos/security/wrappers: use an assertion for the existence check`                                                    |
| [`7149c5cb`](https://github.com/NixOS/nixpkgs/commit/7149c5cb604a0a661c27fc2fc8286ddf0efcee46) | `mpd: fix socket activation`                                                                                           |
| [`d77c1d5c`](https://github.com/NixOS/nixpkgs/commit/d77c1d5c85f7afdf6f1efda9ddd3de7cb6623314) | `dmarc-metrics-exporter: 0.5.1 -> 0.6.0`                                                                               |
| [`e6912f3a`](https://github.com/NixOS/nixpkgs/commit/e6912f3a94945a71c88d48c2669f7ce53da8c3d8) | `python310Packages.bite-parser: 0.1.1 -> 0.1.3`                                                                        |
| [`d574ec79`](https://github.com/NixOS/nixpkgs/commit/d574ec79cb8ed92bda77204f0a3cd6e313ac56e6) | `python310Packages.entrypoint2: 1.0 -> 1.1`                                                                            |
| [`00a84f9f`](https://github.com/NixOS/nixpkgs/commit/00a84f9f2fba3f924888649391078b86c9c61b57) | `palemoon: Fix 31.1.0 bump`                                                                                            |
| [`514bd27e`](https://github.com/NixOS/nixpkgs/commit/514bd27e9210b732ca191695445eb43083e18fe2) | `libreswan: 4.6 -> 4.7`                                                                                                |
| [`547ea4a9`](https://github.com/NixOS/nixpkgs/commit/547ea4a972f64bb1cc4922eb0f2069715da631b1) | `maintainers: add hamburger1984`                                                                                       |
| [`94dba70a`](https://github.com/NixOS/nixpkgs/commit/94dba70a05f3b3bc2048b888203ff9fce8fb8ba2) | `vault-bin: 1.10.3 -> 1.10.4`                                                                                          |
| [`54587c3b`](https://github.com/NixOS/nixpkgs/commit/54587c3b1f3d983bc1d9c50776100f394b01c889) | `vault: 1.10.3 -> 1.10.4`                                                                                              |
| [`5dc09cd8`](https://github.com/NixOS/nixpkgs/commit/5dc09cd84f4456c6d3ce3b601a0c91c15dbccc33) | `linux/hardened/patches/5.4: 5.4.196-hardened1 -> 5.4.197-hardened1`                                                   |
| [`a2c6e437`](https://github.com/NixOS/nixpkgs/commit/a2c6e4372a49bd5d6e2e5ddf2e181ad6a258597c) | `linux/hardened/patches/5.18: init at 5.18.3-hardened1`                                                                |
| [`4bdf850d`](https://github.com/NixOS/nixpkgs/commit/4bdf850d1b42a6f3e93fb767ffada5c55cf24fdf) | `python3Packages.mysql-connector: allow use of clang for darwin`                                                       |
| [`f61e9f4a`](https://github.com/NixOS/nixpkgs/commit/f61e9f4a536c0b0afacd2eace7317f32b33ab778) | `linux/hardened/patches/5.17: 5.17.11-hardened1 -> 5.17.14-hardened1`                                                  |
| [`de36193d`](https://github.com/NixOS/nixpkgs/commit/de36193dee5973147419a5819498f973f2fc6c40) | `linux/hardened/patches/5.15: 5.15.43-hardened1 -> 5.15.46-hardened1`                                                  |
| [`858741e8`](https://github.com/NixOS/nixpkgs/commit/858741e87213845fdb74b87ec50d5fd002ff18ce) | `linux/hardened/patches/5.10: 5.10.118-hardened1 -> 5.10.121-hardened1`                                                |
| [`1c31d966`](https://github.com/NixOS/nixpkgs/commit/1c31d9666e4ad96f06111997870cd43875bf1dc3) | `linux/hardened/patches/4.19: 4.19.245-hardened1 -> 4.19.246-hardened1`                                                |
| [`67a664c5`](https://github.com/NixOS/nixpkgs/commit/67a664c575335508a2f7afc65dbe78151ad1a244) | `linux/hardened/patches/4.14: 4.14.281-hardened1 -> 4.14.282-hardened1`                                                |
| [`87e0009c`](https://github.com/NixOS/nixpkgs/commit/87e0009cd59f73d2f00c481a255b81d80a20e082) | `linux_latest-libre: 18738 -> 18777`                                                                                   |
| [`e457a676`](https://github.com/NixOS/nixpkgs/commit/e457a67642a0460f13b7b64749361d444a0e2d2d) | `linux-rt_5_10: 5.10.115-rt67 -> 5.10.120-rt70`                                                                        |
| [`45a098de`](https://github.com/NixOS/nixpkgs/commit/45a098de80741473ce865f8c091d828a629fd33f) | `linux: 5.4.196 -> 5.4.197`                                                                                            |
| [`260e08a6`](https://github.com/NixOS/nixpkgs/commit/260e08a6e64631a6c04ed6807caf6a96007ee8fb) | `linux: 5.18 -> 5.18.3`                                                                                                |
| [`363c71ff`](https://github.com/NixOS/nixpkgs/commit/363c71ff3cb469f90a4dce78e01eabbe53076d09) | `linux: 5.17.11 -> 5.17.14`                                                                                            |
| [`19d98662`](https://github.com/NixOS/nixpkgs/commit/19d986621529a9cbb8bd9d39a96efea53df99d7d) | `linux: 5.15.43 -> 5.15.46`                                                                                            |
| [`a7757d8a`](https://github.com/NixOS/nixpkgs/commit/a7757d8a946c36a3eab8b340cf3155c71ca1df21) | `linux: 5.10.118 -> 5.10.121`                                                                                          |
| [`2ac8909c`](https://github.com/NixOS/nixpkgs/commit/2ac8909c8b5c7d7e0c19b84e2a8bc703ef5674a2) | `linux: 4.9.316 -> 4.9.317`                                                                                            |
| [`c6c98c48`](https://github.com/NixOS/nixpkgs/commit/c6c98c48b4bb91ad3998b291e79ea1d9110138a0) | `linux: 4.19.245 -> 4.19.246`                                                                                          |
| [`deaf61da`](https://github.com/NixOS/nixpkgs/commit/deaf61dab10a18898bc38065ae760bbfd20240e2) | `linux: 4.14.281 -> 4.14.282`                                                                                          |
| [`b39d5e81`](https://github.com/NixOS/nixpkgs/commit/b39d5e81b168acde8555a6ccbcb937268945a7dd) | `python310Packages.pyunifiprotect: 3.9.1 -> 3.9.2`                                                                     |
| [`f68dd75e`](https://github.com/NixOS/nixpkgs/commit/f68dd75e0b99cf4d4f264758fec900323fd01719) | `python310Packages.pyunifiprotect: 3.9.0 -> 3.9.1`                                                                     |
| [`f3ed3e29`](https://github.com/NixOS/nixpkgs/commit/f3ed3e29aaed442f7954e8c5e5f2b886c00733fb) | `python310Packages.azure-eventhub: 5.9.0 -> 5.10.0`                                                                    |
| [`b8c87def`](https://github.com/NixOS/nixpkgs/commit/b8c87def6591c4c80263fdf2c79f5cdc845ec7bc) | `hydroxide: 0.2.21 -> 0.2.23`                                                                                          |
| [`b05ee647`](https://github.com/NixOS/nixpkgs/commit/b05ee6474a6e232bb0840654e1af86abd0cdf3da) | `python310Packages.azure-servicebus: 7.6.1 -> 7.7.0`                                                                   |
| [`87c7d13b`](https://github.com/NixOS/nixpkgs/commit/87c7d13b22aa0518f7369aeac24894cc21d52396) | `python310Packages.pyunifiprotect: 3.8.0 -> 3.9.0`                                                                     |
| [`d6f80617`](https://github.com/NixOS/nixpkgs/commit/d6f80617a3e667ddc89f2f450c7909873bfb18f6) | `manul: remove`                                                                                                        |
| [`81291cc7`](https://github.com/NixOS/nixpkgs/commit/81291cc793cf88bd6eff3fd8512e5eb9d037066c) | `nixos/grafana: Allow setting UID for datasource`                                                                      |
| [`d61ce444`](https://github.com/NixOS/nixpkgs/commit/d61ce4445c351a8084c0c5411e4acf5a3fbb6daf) | `aegisub: 3.2.2 -> 3.3.2`                                                                                              |