### PR TITLE
chore(flake/null-ls-nvim-src): `96b0a6f0` -> `ff40739e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -580,11 +580,11 @@
     "null-ls-nvim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1655071554,
-        "narHash": "sha256-123ahOIR1UutuJfOzNV/TM6igVQ29Gb+NpPRBhQJ4Mc=",
+        "lastModified": 1655156827,
+        "narHash": "sha256-phOFfVCzE5cQsjGHh8VrarEBZ3huyVXo6S4hq52B1uo=",
         "owner": "jose-elias-alvarez",
         "repo": "null-ls.nvim",
-        "rev": "96b0a6f02f1f4aaec83afb0826ae52733590d329",
+        "rev": "ff40739e5be6581899b43385997e39eecdbf9465",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                           | Commit Message                                                                 |
| ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`ff40739e`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/ff40739e5be6581899b43385997e39eecdbf9465) | `chore: autogen metadata and docs`                                             |
| [`d8236836`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/d823683635bf41aff8437b8f8bec3136af628209) | `chore(builtins): move note under meta key`                                    |
| [`17dd2c95`](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/17dd2c95a7412e97bf9752a5a5cca95581baf361) | `feat: added default runtime condition for cfn_lint diagnostics source (#913)` |