### PR TITLE
chore(flake/nvim-treesitter-context-src): `026e6f40` -> `502e4edd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
     "nvim-treesitter-context-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1654888184,
-        "narHash": "sha256-uoRUqB6rEU8j0MjwrKL3vWFzySCg5PHZBuNqWaziGZc=",
+        "lastModified": 1655213062,
+        "narHash": "sha256-Xslk7PEP61FCidMEp1faOx7cadQ2MffFsM+3CgGrgQM=",
         "owner": "romgrk",
         "repo": "nvim-treesitter-context",
-        "rev": "026e6f407d41f0f8229c067b0a2a19c6ab26bdae",
+        "rev": "502e4edd9d7b29d9038c699cdcf281462860a64f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                                   | Commit Message                            |
| ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
| [`502e4edd`](https://github.com/nvim-treesitter/nvim-treesitter-context/commit/502e4edd9d7b29d9038c699cdcf281462860a64f) | `feat: show trailing return types (#124)` |