### PR TITLE
chore(flake/nixpkgs): `e1a1cfb5` -> `1712ecaa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -464,11 +464,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655122334,
-        "narHash": "sha256-Rwwvo9TDCH0a4m/Jvoq5wZ3FLSLiVLBD1FFfN/3XawA=",
+        "lastModified": 1655211057,
+        "narHash": "sha256-Zs5wm2GuW2nER9uYpgAAxuEqEK3LTo3Y+lwaWn/YYHk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e1a1cfb56504d1b82a3953bfb0632b37a1ca8d30",
+        "rev": "1712ecaa5118815292f57d6669c3c81d84d842b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                         | Commit Message                                                            |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`60ba9d65`](https://github.com/NixOS/nixpkgs/commit/60ba9d65d326687bfec3a68f2c734a32cbbdd038) | `vimPlugins.cmp-*: Add overrides`                                         |
| [`36b54d33`](https://github.com/NixOS/nixpkgs/commit/36b54d333db5928a841d49fccc09b13b999ca004) | `logstash: fix sha256`                                                    |
| [`54d4a1db`](https://github.com/NixOS/nixpkgs/commit/54d4a1db73d19985c128005ca472c1edb56a429a) | `gowitness: init at 2.4.0`                                                |
| [`d12ff557`](https://github.com/NixOS/nixpkgs/commit/d12ff5572571544989aa30abda50136dca81cf4a) | `webanalyze: init at 0.3.6`                                               |
| [`822b8e59`](https://github.com/NixOS/nixpkgs/commit/822b8e59e60d6b6522161a9bfbca8dc673beb5a4) | `homebank: 5.5.4 -> 5.5.5`                                                |
| [`76d82cd7`](https://github.com/NixOS/nixpkgs/commit/76d82cd78a9ac5a766ec74ff3a0c589692242848) | `python310Packages.social-auth-core: handle optional dependencies`        |
| [`bb77639d`](https://github.com/NixOS/nixpkgs/commit/bb77639d025689f4dcab1b09dd54cc8c3f0aa71a) | `python310Packages.social-auth-core: 4.2.0 -> 4.3.0`                      |
| [`c350fd89`](https://github.com/NixOS/nixpkgs/commit/c350fd89201962257e30b98eb404def5c9df671b) | `httm: 0.11.1 -> 0.11.6`                                                  |
| [`452ec5da`](https://github.com/NixOS/nixpkgs/commit/452ec5da7ac4787585ab39deebb294b923ec263b) | `python310Packages.ghapi: 0.1.20 -> 0.1.21`                               |
| [`06393550`](https://github.com/NixOS/nixpkgs/commit/06393550ccb0c8b03cc984d46ab46743cf629e8f) | `python310Packages.peaqevcore: 1.0.11 -> 1.0.14`                          |
| [`f6a39b8d`](https://github.com/NixOS/nixpkgs/commit/f6a39b8d7fef428d553668677069f9c466ea3a1a) | `python310Packages.atom: 0.8.0 -> 0.8.1`                                  |
| [`4067b82a`](https://github.com/NixOS/nixpkgs/commit/4067b82a9be3d24899b7def609b39a5190adb25b) | `flexget: 3.3.16 -> 3.3.17`                                               |
| [`08318d0a`](https://github.com/NixOS/nixpkgs/commit/08318d0ab7730d7424face713bec4936cfd7be5a) | `strawberry: 1.0.4 -> 1.0.5`                                              |
| [`de77c035`](https://github.com/NixOS/nixpkgs/commit/de77c035c47c1cefc5b252e27b911cffb12e1240) | `tor-browser-bundle-bin: 11.0.13 -> 11.0.14`                              |
| [`99647e7a`](https://github.com/NixOS/nixpkgs/commit/99647e7a12b870c97303d437898cd33562183b7c) | `direnv: 2.31.0 -> 2.32.0`                                                |
| [`2e4aac81`](https://github.com/NixOS/nixpkgs/commit/2e4aac819f8418be158f8a1f6708b2efe636ef21) | `ldapmonitor: init at 1.3`                                                |
| [`0631bf95`](https://github.com/NixOS/nixpkgs/commit/0631bf9509f1afcf02edba3ef51326093229ee23) | `liblouis: 3.21.0 → 3.22.0`                                               |
| [`a6da7aad`](https://github.com/NixOS/nixpkgs/commit/a6da7aad396e24fc103f4d47ec0da5798d6e2463) | `python310Packages.azure-mgmt-logic: disable on older Python releases`    |
| [`40067617`](https://github.com/NixOS/nixpkgs/commit/40067617d66fe795a821d1b97bb99b1c5d5e8436) | `python310Packages.velbus-aio: 2022.6.1 -> 20212.6.2`                     |
| [`49eab7a5`](https://github.com/NixOS/nixpkgs/commit/49eab7a5a52626497bfabd532c5656f74c059e37) | `tfsec: 1.23.3 -> 1.24.0`                                                 |
| [`e05dc87e`](https://github.com/NixOS/nixpkgs/commit/e05dc87e4153d1435e24629d5a8aea847ae2aa5c) | `vimPlugins.fuzzy-nvim: init at 2022-02-20`                               |
| [`fdaa8fc6`](https://github.com/NixOS/nixpkgs/commit/fdaa8fc610c001173a29642b363e363b60f3c659) | `vimPlugins.nvim-snippy: init at 2022-05-01`                              |
| [`dafc5add`](https://github.com/NixOS/nixpkgs/commit/dafc5addaad24eb734cb6fbc47af63cf0c0286a2) | `vimPlugins.cmp-dap: init at 2022-04-27`                                  |
| [`843fd830`](https://github.com/NixOS/nixpkgs/commit/843fd83017b4ba38a4ec511916688aba2dd12323) | `vimPlugins.cmp-vimwiki-tags: init at 2022-04-25`                         |
| [`36e86164`](https://github.com/NixOS/nixpkgs/commit/36e86164d985d1244e606be07ff40f2e917a7ca8) | `vimPlugins.cmp-pandoc-nvim: init at 2022-05-03`                          |
| [`dd378843`](https://github.com/NixOS/nixpkgs/commit/dd3788435ae42fb6fe20c649345fdde72766de04) | `vimPlugins.cmp-look: init at 2022-03-21`                                 |
| [`cbaec802`](https://github.com/NixOS/nixpkgs/commit/cbaec802b4c39b8388136a6bc1de7c2b945e4ab3) | `vimPlugins.cmp-greek: init at 2022-01-10`                                |
| [`028ad31f`](https://github.com/NixOS/nixpkgs/commit/028ad31f5d3fa70688d62ba2fabf509dbe0d28ae) | `vimPlugins.cmp-nvim-tags: init at 2022-03-31`                            |
| [`4704008b`](https://github.com/NixOS/nixpkgs/commit/4704008b8b65bd6673881cc9ce6c618a2a11e693) | `vimPlugins.cmp-copilot: init at 2022-04-11`                              |
| [`12e88c59`](https://github.com/NixOS/nixpkgs/commit/12e88c597712e3529d8782206032449aa1ef8ef2) | `vimPlugins.cmp-clippy: init at 2021-10-24`                               |
| [`f8459245`](https://github.com/NixOS/nixpkgs/commit/f845924568b3cc4a6b05c85ec881c2632b1f3d16) | `vimPlugins.cmp-npm: init at 2021-10-27`                                  |
| [`82e3d312`](https://github.com/NixOS/nixpkgs/commit/82e3d3122b371b5d5390aa8c7e3add845f7796a4) | `vimPlugins.cmp-zsh: init at 2022-01-18`                                  |
| [`b6e370d2`](https://github.com/NixOS/nixpkgs/commit/b6e370d29140b55fd11ec4b08074d4d0b940b21a) | `vimPlugins.cmp-fish: init at 2022-02-17`                                 |
| [`586ed454`](https://github.com/NixOS/nixpkgs/commit/586ed4541b6ffdb38d5e7ab53efa074acb66235a) | `vimPlugins.cmp-rg: init at 2022-01-13`                                   |
| [`61446044`](https://github.com/NixOS/nixpkgs/commit/6144604447a3c32eac51b17a298f86752b8fc787) | `vimPlugins.cmp-fuzzy-path: init at 2022-05-08`                           |
| [`010ef3dc`](https://github.com/NixOS/nixpkgs/commit/010ef3dc36ff05ec033d1a75635b3eedacc28de6) | `vimPlugins.cmp-fuzzy-buffer: init at 2022-01-13`                         |
| [`aa87d478`](https://github.com/NixOS/nixpkgs/commit/aa87d4786964b66b51c11b749c6685f374a43431) | `vimPlugins.cmp-cmdline-history: init at 2022-05-04`                      |
| [`96fcb504`](https://github.com/NixOS/nixpkgs/commit/96fcb504d1f586908d20b95e49ca6781a5c9205c) | `vimPlugins.cmp-conventionalcommits: init at 2021-10-28`                  |
| [`14d7a9c4`](https://github.com/NixOS/nixpkgs/commit/14d7a9c473d41869e3e5a7d31d6a2a37acedccfa) | `vimPlugins.cmp-git: init at 2022-05-11`                                  |
| [`68dd2e5c`](https://github.com/NixOS/nixpkgs/commit/68dd2e5c8a5277c4ca2ea6ab253064d48abdfcee) | `vimPlugins.cmp-vim-lsp: init at 2021-10-26`                              |
| [`9782b816`](https://github.com/NixOS/nixpkgs/commit/9782b8161e8bd63dfa4e0f4da35a7145db010bf2) | `vimPlugins.cmp-nvim-lsp-signature-help: init at 2022-03-29`              |
| [`bcb28592`](https://github.com/NixOS/nixpkgs/commit/bcb285921bc134b18468452998bb114a88e93415) | `vimPlugins.cmp-digraphs: init at 2021-12-13`                             |
| [`0d921381`](https://github.com/NixOS/nixpkgs/commit/0d921381b640c30323432f8a4dcb0c272a83ca0e) | `vimPlugins.cmp-dictionary: init at 2022-05-04`                           |
| [`43c23c91`](https://github.com/NixOS/nixpkgs/commit/43c23c919e592d79943011b9a8a992b9edd58076) | `vimPlugins.cmp-snippy: init at 2021-09-20`                               |
| [`865a32dd`](https://github.com/NixOS/nixpkgs/commit/865a32dd51fa796ec105ff7fa72735b3a5529e5b) | `vimPlugins.cmp-neosnippet: init at 2022-01-06`                           |
| [`afb6182f`](https://github.com/NixOS/nixpkgs/commit/afb6182f9a3f3b14eb63a250e4b6fb2f4ad7efd3) | `libnfc: specify license`                                                 |
| [`222fe563`](https://github.com/NixOS/nixpkgs/commit/222fe563b95464cea880334603dc313ae79b759b) | `palemoon: Limit build cores count`                                       |
| [`b1ff292b`](https://github.com/NixOS/nixpkgs/commit/b1ff292b1a9f3d875388455ae4eff4858f6dcc69) | `nixos/tests/jellyfin: fix type errors in test script`                    |
| [`1f31dbf1`](https://github.com/NixOS/nixpkgs/commit/1f31dbf1ec76d986d56c7c5391245e7bf0ba44d6) | `ocamlPackages.cry: 0.6.5 -> 0.6.7`                                       |
| [`38c776b6`](https://github.com/NixOS/nixpkgs/commit/38c776b6799195fae58808b19d9b19d198ca2896) | `stdenv/check-meta: support NIXPKGS_ALLOW_NONSOURCE=0`                    |
| [`09757c2b`](https://github.com/NixOS/nixpkgs/commit/09757c2b254a67568858ac3ef6b5538f1cb413d8) | `haveged: 1.9.17 -> 1.9.18`                                               |
| [`d7fa12bd`](https://github.com/NixOS/nixpkgs/commit/d7fa12bd189895b0510a9087b2e89899fd07892f) | `hash-slinger: 3.1 -> 3.2`                                                |
| [`df9425f1`](https://github.com/NixOS/nixpkgs/commit/df9425f1b2071837a7212cfd199b2caf99eda9cf) | `etcher: mark meta.sourceProvenance`                                      |
| [`cce03bad`](https://github.com/NixOS/nixpkgs/commit/cce03bad2d18f7912c0ce9ca2b8c819c3a8d464e) | `signal-desktop: mark meta.sourceProvenance`                              |
| [`0ca71677`](https://github.com/NixOS/nixpkgs/commit/0ca71677b4dd036f6294da21b0d34543cf2ae294) | `electron: mark meta.sourceProvenance`                                    |
| [`6ca8a394`](https://github.com/NixOS/nixpkgs/commit/6ca8a3944f8f80d3850d2fac95e7bc0bd07104b4) | `checksec: 2.5.0 -> 2.6.0`                                                |
| [`2c7a74c9`](https://github.com/NixOS/nixpkgs/commit/2c7a74c9925187476c7cd4f5dd227742b0c9a19a) | `vimPlugins.lspcontainers: init`                                          |
| [`8722479f`](https://github.com/NixOS/nixpkgs/commit/8722479fd45611b9827850965653c49ddfdc79e8) | `aws-iam-authenticator: fix ldflags`                                      |
| [`41d033fc`](https://github.com/NixOS/nixpkgs/commit/41d033fc50f59caeb58f1facdf5cd6ddb3947e48) | `watchlog: init at 1.152.0`                                               |
| [`4ecbbe38`](https://github.com/NixOS/nixpkgs/commit/4ecbbe38052e2d99884c4ac2422905c0032cdb7c) | `atomic-operator: init at 0.8.5`                                          |
| [`ee4b07bd`](https://github.com/NixOS/nixpkgs/commit/ee4b07bdd0f05059a0c2c12870d08ee70574dfc2) | `python310Packages.pick. init at 1.2.0`                                   |
| [`9e603ba5`](https://github.com/NixOS/nixpkgs/commit/9e603ba5f13c6da2948fd949f51dd7e47ba18a0f) | `mitmproxy2swagger: init at 0.6.0`                                        |
| [`64305297`](https://github.com/NixOS/nixpkgs/commit/64305297adc748610ac3b3e75ce6303e9622101e) | `python310Packages.json-stream: init at 1.3.0`                            |
| [`3cd7e5c7`](https://github.com/NixOS/nixpkgs/commit/3cd7e5c783945d4246e2e58f2c5e827cc3f97d3e) | `python310Packages.dvclive: 0.8.2 -> 0.9.0`                               |
| [`07ab3e4d`](https://github.com/NixOS/nixpkgs/commit/07ab3e4dc885040fc099102e8cd072e1f2d4f598) | `python310Packages.dvc-render: 0.0.5 -> 0.0.6`                            |
| [`b8df14ae`](https://github.com/NixOS/nixpkgs/commit/b8df14aec0a7ee98eb54dd8e476910cce7718f0c) | `tests/terminal-emulators: comply with mypy typecheck`                    |
| [`f74debc9`](https://github.com/NixOS/nixpkgs/commit/f74debc95fcca5f7a9b0ae3e31335e5bdefe062d) | `dnsdist: 1.7.0 -> 1.7.1`                                                 |
| [`d22931cf`](https://github.com/NixOS/nixpkgs/commit/d22931cf0541895330b2d295a7be563e7a572231) | `raven-reader: 1.0.72 -> 1.0.73`                                          |
| [`02cd4871`](https://github.com/NixOS/nixpkgs/commit/02cd48717d5249876b181cf9555a48041dd33ae7) | `nixos/openldap: fix systemd rejecting notification (#177084)`            |
| [`a1ad2357`](https://github.com/NixOS/nixpkgs/commit/a1ad23574310f0ca7aedd916192855a3e2a46729) | `vimUtils: deprecate configure.pathogen (#154814)`                        |
| [`44248105`](https://github.com/NixOS/nixpkgs/commit/442481052a4819cdba2c7acce0f9e6ac45ae1475) | `libnfc: fix build on darwin`                                             |
| [`877b86fb`](https://github.com/NixOS/nixpkgs/commit/877b86fb372fee841f34f9ae3413808d869dc1b1) | `python310Packages.pyinsteon: 1.1.0 -> 1.1.1`                             |
| [`3cf3911f`](https://github.com/NixOS/nixpkgs/commit/3cf3911f79abb0c1db989f0c2d8da3b6cea57bc5) | `python310Packages.azure-mgmt-logic: 9.0.0 -> 10.0.0`                     |
| [`d339c458`](https://github.com/NixOS/nixpkgs/commit/d339c458150b99b47769c7ca163fd65b5d3af06c) | `catt: 0.12.2 -> 0.12.7`                                                  |
| [`5e7840d6`](https://github.com/NixOS/nixpkgs/commit/5e7840d676d48d9a57a93b3115cdebe7317c46a9) | `clair: 4.4.2 -> 4.4.4`                                                   |
| [`accc92f0`](https://github.com/NixOS/nixpkgs/commit/accc92f06057c8653969d77389a39fe7bfaebde0) | `element-{web,desktop}: 1.10.13 -> 1.10.14`                               |
| [`695fe7d2`](https://github.com/NixOS/nixpkgs/commit/695fe7d25305da01262482bb2c6fc62abc81ac06) | `kubeaudit: 0.17.0 -> 0.18.0`                                             |
| [`edd50437`](https://github.com/NixOS/nixpkgs/commit/edd50437bdc9603c6318543162a607e1ff6fb0fa) | `checkov: 2.0.1209 -> 2.0.1210`                                           |
| [`1210f3c2`](https://github.com/NixOS/nixpkgs/commit/1210f3c24c796bda2889849975081930a225fa26) | `python310Packages.pyroute2-ipset: 0.6.11 -> 0.6.12`                      |
| [`0d462f55`](https://github.com/NixOS/nixpkgs/commit/0d462f55f3f9e4472e47b29a940b86a25cd33728) | `python310Packages.pyroute2: 0.6.11 -> 0.6.12`                            |
| [`985d6dd9`](https://github.com/NixOS/nixpkgs/commit/985d6dd96e943ecd6a9fe1155b3362bb98f8be54) | `python310Packages.pyroute2-protocols: 0.6.11 -> 0.6.12`                  |
| [`d85e4c28`](https://github.com/NixOS/nixpkgs/commit/d85e4c28730447a78c44a7c25d68207346892502) | `python310Packages.pyroute2-nslink: 0.6.11 -> 0.6.12`                     |
| [`f6301f1a`](https://github.com/NixOS/nixpkgs/commit/f6301f1ac5d4bfcaaba0bffcaf5fa6b205b7e60c) | `python310Packages.pyroute2-nftables: 0.6.11 -> 0.6.12`                   |
| [`002a5c99`](https://github.com/NixOS/nixpkgs/commit/002a5c995517125cff49539591461bd52d4355a6) | `python310Packages.pyroute2-ndb: 0.6.11 -> 0.6.12`                        |
| [`3341e2c5`](https://github.com/NixOS/nixpkgs/commit/3341e2c570534a734882187a94d53ca6032ad996) | `python310Packages.pyroute2-ipdb: 0.6.11 -> 0.6.12`                       |
| [`5fb659f6`](https://github.com/NixOS/nixpkgs/commit/5fb659f697125a6e3ba50f033821348087d45dbd) | `python310Packages.pyroute2-ethtool: 0.6.11 -> 0.6.12`                    |
| [`02bd9fcc`](https://github.com/NixOS/nixpkgs/commit/02bd9fccc35e6eb1c90a565246685a64bb48691c) | `python310Packages.pyroute2-core: 0.6.11 -> 0.6.12`                       |
| [`fa733534`](https://github.com/NixOS/nixpkgs/commit/fa7335347aee4351b91fe144376fbcc0c0795e61) | `httpx: 1.2.1 -> 1.2.2`                                                   |
| [`75a0709f`](https://github.com/NixOS/nixpkgs/commit/75a0709f6733ae627998eb718f2a4602c0cff1b7) | `luaPackages.busted: install shell completion via installShellCompletion` |
| [`dd9df750`](https://github.com/NixOS/nixpkgs/commit/dd9df750ba87f19b3f3b205caf9011d1447d59b9) | `luaPackages.readline: fix build`                                         |
| [`83313fee`](https://github.com/NixOS/nixpkgs/commit/83313fee5c44199ad96f4cac9526f5b514f9f93b) | `luaPackages.lua-lsp: fixed build`                                        |
| [`98f9f1f0`](https://github.com/NixOS/nixpkgs/commit/98f9f1f05447a3fd97af44c2702ca71554ddfac2) | `luaPackages.luv: fix build`                                              |
| [`98a90f08`](https://github.com/NixOS/nixpkgs/commit/98a90f08913202940121d0e7e85cdf11c5a1bc0e) | `luaPackages: update`                                                     |
| [`fb6f9ee2`](https://github.com/NixOS/nixpkgs/commit/fb6f9ee28ff6c57f4ab697a1db782e89a744f547) | `update-luarocks-package: fix mirrors`                                    |
| [`77a0e5f3`](https://github.com/NixOS/nixpkgs/commit/77a0e5f36e758ec62354919bd4dcc28b9eeebe3c) | `luarocks: 3.8.0 -> 3.9.0`                                                |
| [`022562fc`](https://github.com/NixOS/nixpkgs/commit/022562fcf01b5e4abdf1018e7f0eab401c0d9258) | `offensive-azure: init at 0.4.10`                                         |
| [`ee0c2902`](https://github.com/NixOS/nixpkgs/commit/ee0c29026ad4f5fa88ff1e1c4f358bb6b07a9d45) | `crlfsuite: init at 2.0`                                                  |
| [`1cd4b21e`](https://github.com/NixOS/nixpkgs/commit/1cd4b21e0744ffa775b50d7c76e36cff761d6496) | `smbscan: init at unstable-2022-05-26`                                    |
| [`77248491`](https://github.com/NixOS/nixpkgs/commit/772484911ca7a5cc71eac4a30395b8bf62f71d9e) | `python310Packages.aiohue: 4.4.1 -> 4.4.2`                                |
| [`d7500fd8`](https://github.com/NixOS/nixpkgs/commit/d7500fd8ef428c3c13b5e35644c0590b9e124eec) | `dnsrecon: 1.1.0 -> 1.1.1`                                                |
| [`1f980689`](https://github.com/NixOS/nixpkgs/commit/1f9806891d18c3f984e41f56fe0cc4458ee01e29) | `dnsrecon: 1.0.0 -> 1.1.0`                                                |
| [`68c360c5`](https://github.com/NixOS/nixpkgs/commit/68c360c518091f0e2d355dd3aa7186f4e8da0935) | `polymc: 1.3.1 -> 1.3.2`                                                  |
| [`d8ba6b40`](https://github.com/NixOS/nixpkgs/commit/d8ba6b400be7cfd4a1a6ae6bc3de7cba7f215d51) | `dynamips: 0.2.21 -> 0.2.22`                                              |
| [`172a1d93`](https://github.com/NixOS/nixpkgs/commit/172a1d93973a7ac6371ad63f8fe2e46f7e7ef3d9) | `bundler-audit: 0.9.0.1 -> 0.9.1`                                         |
| [`fa01afcf`](https://github.com/NixOS/nixpkgs/commit/fa01afcf7f4d98dc7953fb3ac22f68108d4a57d7) | `doc: Promote config Options Reference to sub-chapter section`            |
| [`85213b6b`](https://github.com/NixOS/nixpkgs/commit/85213b6b412e00b3f37c6a2e81dd5e43a4e28e71) | `python3Packages.aws-adfs: fix build`                                     |
| [`b661c34a`](https://github.com/NixOS/nixpkgs/commit/b661c34a10aacb5dd4ec957655d2f9a0288aa3b3) | `redis: 7.0.0 -> 7.0.2`                                                   |
| [`63174f9b`](https://github.com/NixOS/nixpkgs/commit/63174f9b6f650f511cf05689c85e33588ba5f85a) | `_1password: 2.3.1 -> 2.4.1`                                              |
| [`25cdb44f`](https://github.com/NixOS/nixpkgs/commit/25cdb44ff0312f7f4fbccde4850401fd5d66b5a8) | `jellyfin-mpv-shim: 2.0.2 -> 2.1.0`                                       |
| [`b0e09fde`](https://github.com/NixOS/nixpkgs/commit/b0e09fdea3ec0eb9b1a273a01a830a7677808f44) | `jellyfin: 10.7.7 -> 10.8.0`                                              |
| [`be8ccf1b`](https://github.com/NixOS/nixpkgs/commit/be8ccf1bf251b4123051d3217a504539f034119a) | `jellyfin-web: 10.7.7 -> 10.8.0`                                          |
| [`4e38070d`](https://github.com/NixOS/nixpkgs/commit/4e38070d6ae8bda38b7ac03cb5ca0849761c7c2d) | `diffoscope: 215 -> 216`                                                  |
| [`7da38d0f`](https://github.com/NixOS/nixpkgs/commit/7da38d0f4a2b03dc5182e65a5bd87c45837ef55d) | `pythonPackages.myst-parser: init at 0.18.0`                              |
| [`737da091`](https://github.com/NixOS/nixpkgs/commit/737da0915746fa4a297e7cd6d66e34126d190ee1) | `pythonPackages.pytest-param-files: init at 0.3.4`                        |
| [`eafcfbf6`](https://github.com/NixOS/nixpkgs/commit/eafcfbf6e5af2916cb5689d4927647a57ce71175) | `pythonPackages.sphinx-pytest: init at 0.0.3`                             |
| [`92d8ebcd`](https://github.com/NixOS/nixpkgs/commit/92d8ebcd0d42ca1982258ac8e155482a97e18677) | `neil: 0.0.23 -> 0.0.31`                                                  |
| [`35f3cb8c`](https://github.com/NixOS/nixpkgs/commit/35f3cb8c6e2e08fec29209d096733d7cc68dc655) | `xorg.xf86videoxgi: pull upstream fix for -fno-common toolchains`         |
| [`dfbb9600`](https://github.com/NixOS/nixpkgs/commit/dfbb960094c6136dd7fe2829427bd5af6d97f7ce) | `tvheadend: pull upstream fix for -fno-common toolchains`                 |
| [`ce5eca92`](https://github.com/NixOS/nixpkgs/commit/ce5eca92f157e9f4fc7c2f5566fc2f8beff14d0a) | `rocksndiamonds: pull upstream fix for -fno-common toolchains`            |
| [`1ee09a25`](https://github.com/NixOS/nixpkgs/commit/1ee09a25e808abf4d8d65f3900ba6aef2cd028b6) | `neverball: pull upstream fix for -fno-common toolchains`                 |
| [`7762092a`](https://github.com/NixOS/nixpkgs/commit/7762092a32b66f53ee828a99f5d192a81acf24af) | `vimPlugins.nvim-lastplace: init at 2021-10-15`                           |
| [`e5a1277c`](https://github.com/NixOS/nixpkgs/commit/e5a1277cf6e50263834fa5cfff430bc9173f1acc) | `vimPlugins: update`                                                      |
| [`0b7397aa`](https://github.com/NixOS/nixpkgs/commit/0b7397aadb5b1cc71da9003f3c68984c3a1216ee) | `spdx-license-list-data: 3.16 -> 3.17`                                    |
| [`1eca09a8`](https://github.com/NixOS/nixpkgs/commit/1eca09a8a139354702eb90f0bd85670067eb71ed) | `mlton: 20180207 → 20210107`                                              |